### PR TITLE
feat: add support for sign & signature verify operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ See [examples](./examples) for more possibilities.
 | Re-key Key Pair      |  N/A |  ❌  |  ❌  |  ❌  |  ❌  |
 | Encrypt              |  N/A |  N/A |  ✅  |  ✅  |  ✅  |
 | Decrypt              |  N/A |  N/A |  ✅  |  ✅  |  ✅  |
-| Sign                 |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
-| Signature Verify     |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
+| Sign                 |  N/A |  N/A |  ✅  |  ✅  |  ✅  |
+| Signature Verify     |  N/A |  N/A |  ✅  |  ✅  |  ✅  |
 | MAC                  |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
 | MAC Verify           |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
 | RNG Retrieve         |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
@@ -208,20 +208,20 @@ See [examples](./examples) for more possibilities.
 | Transparent Key Structures               |  🚧  |  🚧  |  🚧  |  🚧  |  🚧  |
 | Template-Attribute Structures            |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Extension Information                    |  N/A |  ✅  |  ✅  |  ✅  |  ✅  |
-| Data                                     |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
+| Data                                     |  N/A |  N/A |  ✅  |  ✅  |  ✅  |
 | Data Length                              |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
-| Signature Data                           |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
+| Signature Data                           |  N/A |  N/A |  ✅  |  ✅  |  ✅  |
 | MAC Data                                 |  N/A |  N/A |  ❌  |  ❌  |  ❌  |
 | Nonce                                    |  N/A |  N/A |  ✅  |  ✅  |  ✅  |
-| Correlation Value                        |  N/A |  N/A |  N/A |  ❌  |  ❌  |
-| Init Indicator                           |  N/A |  N/A |  N/A |  ❌  |  ❌  |
-| Final Indicator                          |  N/A |  N/A |  N/A |  ❌  |  ❌  |
+| Correlation Value                        |  N/A |  N/A |  N/A |  ✅  |  ✅  |
+| Init Indicator                           |  N/A |  N/A |  N/A |  ✅  |  ✅  |
+| Final Indicator                          |  N/A |  N/A |  N/A |  ✅  |  ✅  |
 | RNG Parameter                            |  N/A |  N/A |  N/A |  ✅  |  ✅  |
 | Profile Information                      |  N/A |  N/A |  N/A |  ✅  |  ✅  |
 | Validation Information                   |  N/A |  N/A |  N/A |  ✅  |  ✅  |
 | Capability Information                   |  N/A |  N/A |  N/A |  ✅  |  ✅  |
-| Authenticated Encryption Additional Data |  N/A |  N/A |  N/A |  N/A |  ❌  |
-| Authenticated Encryption Tag             |  N/A |  N/A |  N/A |  N/A |  ❌  |
+| Authenticated Encryption Additional Data |  N/A |  N/A |  N/A |  N/A |  ✅  |
+| Authenticated Encryption Tag             |  N/A |  N/A |  N/A |  N/A |  ✅  |
 
 #### Transparent Key Structures
 | Object                   | v1.0 | v1.1 | v1.2 | v1.3 | v1.4 |

--- a/enums.go
+++ b/enums.go
@@ -454,6 +454,11 @@ func init() {
 		KeyValueLocationTypeUninterpretedTextString: "UninterpretedTextString",
 		KeyValueLocationTypeURI:                     "URI",
 	})
+	ttlv.RegisterEnum(TagValidityIndicator, map[ValidityIndicator]string{
+		ValidityIndicatorValid:   "Valid",
+		ValidityIndicatorInvalid: "Invalid",
+		ValidityIndicatorUnknown: "Unknown",
+	})
 
 	ttlv.RegisterEnum(TagRNGAlgorithm, map[RNGAlgorithm]string{
 		RNGAlgorithmUnspecified: "Unspecified",
@@ -1318,6 +1323,14 @@ const (
 	KeyValueLocationTypeURI                     KeyValueLocationType = 0x00000002
 )
 
+type ValidityIndicator uint32
+
+const (
+	ValidityIndicatorValid   ValidityIndicator = 0x00000001
+	ValidityIndicatorInvalid ValidityIndicator = 0x00000002
+	ValidityIndicatorUnknown ValidityIndicator = 0x00000003
+)
+
 // KMIP 1.3
 
 type RNGAlgorithm uint32
@@ -1687,6 +1700,9 @@ func (enum AlternativeNameType) MarshalText() ([]byte, error) {
 	return []byte(ttlv.EnumStr(enum)), nil
 }
 func (enum KeyValueLocationType) MarshalText() ([]byte, error) {
+	return []byte(ttlv.EnumStr(enum)), nil
+}
+func (enum ValidityIndicator) MarshalText() ([]byte, error) {
 	return []byte(ttlv.EnumStr(enum)), nil
 }
 func (enum RNGAlgorithm) MarshalText() ([]byte, error) {

--- a/kmiptest/oasis_tc.go
+++ b/kmiptest/oasis_tc.go
@@ -108,35 +108,7 @@ var UnsupportedTestCases = []string{
 	"v1.2/TC_SJ_2_12_Register_and_Split_Join.xml",
 	"v1.2/TC_SJ_3_12_Join_Split_Keys.xml",
 	"v1.2/TC_SJ_4_12_Register_and_Split_Join_with_XOR.xml",
-	"v1.3/CS-AC-M-2-13.xml",
-	"v1.3/CS-AC-M-3-13.xml",
-	"v1.3/CS-AC-M-3-ECC-13.xml",
-	"v1.3/CS-AC-M-5-13.xml",
-	"v1.3/CS-AC-M-6-13.xml",
-	"v1.4/CS-AC-M-2-14.xml",
-	"v1.4/CS-AC-M-3-14.xml",
-	"v1.4/CS-AC-M-5-14.xml",
-	"v1.4/CS-AC-M-6-14.xml",
 	"v1.4/TC-DERIVEKEY-1-10.xml",
-	"v1.4/TC-ECDSA-SIGN-1-14.xml",
 	"v1.4/TC-NP-1-14.xml",
 	"v1.4/TC-SJ-1-14.xml",
 }
-
-// func RunTestSuites(t *testing.T, f func(*testing.T, TestSuite)) {
-// 	for _, vers := range []string{"v1.0", "v1.1", "v1.2", "v1.3", "v1.4"} {
-// 		suites := ListTestSuites(t, vers)
-
-// 		for _, e := range suites {
-// 			name := vers + "/" + e
-// 			t.Run(name, func(t *testing.T) {
-// 				if slices.Contains(toSkip, name) {
-// 					t.Skip("Test case not supported")
-// 				}
-
-// 				ts := LoadTestSuite(t, vers, e)
-// 				f(t, ts)
-// 			})
-// 		}
-// 	}
-// }

--- a/payloads/create.go
+++ b/payloads/create.go
@@ -18,7 +18,7 @@ type CreateRequestPayload struct {
 	ObjectType kmip.ObjectType
 	// Specifies desired attributes using to be associated with the new object templates and/or individual attributes.
 	//
-	//The Template Managed Object is deprecated as of version 1.3 of this specification and MAY be removed from subsequent versions of the specification.
+	// The Template Managed Object is deprecated as of version 1.3 of this specification and MAY be removed from subsequent versions of the specification.
 	// Individual Attributes SHOULD be used in operations which currently support use of a Name within a Template-Attribute to reference a Template.
 	TemplateAttribute kmip.TemplateAttribute
 }

--- a/payloads/create_keypair.go
+++ b/payloads/create_keypair.go
@@ -49,7 +49,7 @@ func (a *CreateKeyPairRequestPayload) Operation() kmip.Operation {
 	return kmip.OperationCreateKeyPair
 }
 
-// Response for the create key-pair operation
+// Response for the create key-pair operation.
 type CreateKeyPairResponsePayload struct {
 	// The Unique Identifier of the newly created Private Key object.
 	PrivateKeyUniqueIdentifier string

--- a/payloads/get.go
+++ b/payloads/get.go
@@ -62,14 +62,14 @@ func (pl *GetResponsePayload) Operation() kmip.Operation {
 
 func (pl *GetResponsePayload) TagDecodeTTLV(d *ttlv.Decoder, tag int) error {
 	return d.Struct(tag, func(d *ttlv.Decoder) error {
-		var err error
-		if err = d.Any(&pl.ObjectType); err != nil {
+		if err := d.Any(&pl.ObjectType); err != nil {
 			return err
 		}
-		if err = d.TagAny(kmip.TagUniqueIdentifier, &pl.UniqueIdentifier); err != nil {
+		if err := d.TagAny(kmip.TagUniqueIdentifier, &pl.UniqueIdentifier); err != nil {
 			return err
 		}
 
+		var err error
 		if pl.Object, err = kmip.NewObjectForType(pl.ObjectType); err != nil {
 			return err
 		}

--- a/payloads/register.go
+++ b/payloads/register.go
@@ -43,14 +43,14 @@ func (pl *RegisterRequestPayload) Operation() kmip.Operation {
 
 func (pl *RegisterRequestPayload) TagDecodeTTLV(d *ttlv.Decoder, tag int) error {
 	return d.Struct(tag, func(d *ttlv.Decoder) error {
-		var err error
-		if err = d.Any(&pl.ObjectType); err != nil {
+		if err := d.Any(&pl.ObjectType); err != nil {
 			return err
 		}
-		if err = d.Any(&pl.TemplateAttribute); err != nil {
+		if err := d.Any(&pl.TemplateAttribute); err != nil {
 			return err
 		}
 
+		var err error
 		if pl.Object, err = kmip.NewObjectForType(pl.ObjectType); err != nil {
 			return err
 		}

--- a/payloads/sign_verify.go
+++ b/payloads/sign_verify.go
@@ -1,0 +1,126 @@
+package payloads
+
+import "github.com/ovh/kmip-go"
+
+func init() {
+	kmip.RegisterOperationPayload[SignRequestPayload, SignResponsePayload](kmip.OperationSign)
+	kmip.RegisterOperationPayload[SignatureVerifyRequestPayload, SignatureVerifyResponsePayload](kmip.OperationSignatureVerify)
+}
+
+// This operation requests the server to perform a signature operation on the provided data using a
+// Managed Cryptographic Object as the key for the signature operation.
+// The request contains information about the cryptographic parameters (digital signature algorithm or
+// cryptographic algorithm and hash algorithm) and the data to be signed. The cryptographic parameters
+// MAY be omitted from the request as they can be specified as associated attributes of the Managed
+// Cryptographic Object.
+//
+// If the Managed Cryptographic Object referenced has a Usage Limits attribute then the server SHALL
+// obtain an allocation from the current Usage Limits value prior to performing the signing operation. If the
+// allocation is unable to be obtained the operation SHALL return with a result status of Operation Failed
+// and result reason of Permission Denied.
+type SignRequestPayload struct {
+	// The Unique Identifier of the Managed Cryptographic Object that is the key to use for the signature operation. If
+	// omitted, then the ID Placeholder value SHALL be used by the server as the Unique Identifier.
+	UniqueIdentifier *string
+	// The Cryptographic Parameters (Digital Signature Algorithm or Cryptographic Algorithm and Hashing Algorithm) corresponding
+	// to the particular signature generation method requested. If omitted then the Cryptographic Parameters associated
+	// with the Managed Cryptographic Object with the lowest Attribute Index SHALL be used.
+	// If there are no Cryptographic Parameters associated with the Managed Cryptographic Object and the algorithm requires parameters then
+	// the operation SHALL return with a Result Status of Operation Failed.
+	CryptographicParameters *kmip.CryptographicParameters
+	// The data to be signed. Mandatory for kmip 1.2 or single-part operation, unless Digested Data is supplied. Optional for multi-part.
+	Data *[]byte
+	// The digested data to be signed.
+	DigestedData *[]byte `ttlv:",version=v1.4.."`
+	// Specifies the existing stream or by parts cryptographic operation (as returned from a previous call to this operation).
+	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	// Initial operation.
+	InitIndicator *bool `ttlv:",version=v1.3.."`
+	// Final operation.
+	FinalIndicator *bool `ttlv:",version=v1.3.."`
+}
+
+func (pl *SignRequestPayload) Operation() kmip.Operation {
+	return kmip.OperationSign
+}
+
+// Response for the sign operation.
+//
+// The response contains the Unique Identifier of the Managed Cryptographic Object used as the key and
+// the result of the signature operation.
+//
+// The success or failure of the operation is indicated by the Result Status (and if failure the Result Reason)
+// in the response header.
+type SignResponsePayload struct {
+	// The Unique Identifier of the Managed Cryptographic Object that is the key used for the signature operation.
+	UniqueIdentifier string
+	// The signed data. Mandatory for kmip 1.2 or single-part operation, not for multi-part.
+	SignatureData *[]byte
+	// Specifies the stream or by-parts value to be provided in subsequent calls to this operation for performing cryptographic operations.
+	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+}
+
+func (pl *SignResponsePayload) Operation() kmip.Operation {
+	return kmip.OperationSign
+}
+
+// This operation requests the server to perform a signature verify operation on the provided data using a
+// Managed Cryptographic Object as the key for the signature verification operation.
+// The request contains information about the cryptographic parameters (digital signature algorithm or
+// cryptographic algorithm and hash algorithm) and the signature to be verified and MAY contain the data
+// that was passed to the signing operation (for those algorithms which need the original data to verify a
+// signature).
+//
+// The cryptographic parameters MAY be omitted from the request as they can be specified as associated
+// attributes of the Managed Cryptographic Object.
+type SignatureVerifyRequestPayload struct {
+	// The Unique Identifier of the Managed Cryptographic Object that is the key to use for the signature verify operation.
+	// If omitted, then the ID Placeholder value SHALL be used by the server as the Unique Identifier.
+	UniqueIdentifier *string
+	// The Cryptographic Parameters (Digital Signature Algorithm or Cryptographic Algorithm and Hashing Algorithm)
+	// corresponding to the particular signature verification method requested. If omitted then the Cryptographic
+	// Parameters associated with the Managed Cryptographic Object with the lowest Attribute Index SHALL be used.
+	//
+	// If there are no Cryptographic Parameters associated with the Managed Cryptographic Object and the algorithm requires
+	// parameters then the operation SHALL return with a Result Status of Operation Failed.
+	CryptographicParameters *kmip.CryptographicParameters
+	// The data that was signed.
+	Data *[]byte
+	// The digested data to be verified.
+	DigestedData *[]byte `ttlv:",version=v1.4.."`
+	// The signature to be verified. Mandatory for kmip 1.2 or for single-part operation. Not for multi-part.
+	SignatureData *[]byte
+	// Specifies the existing stream or by-parts cryptographic operation (as returned from a previous call to this operation).
+	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	// Initial operation.
+	InitIndicator *bool `ttlv:",version=v1.3.."`
+	// Final operation.
+	FinalIndicator *bool `ttlv:",version=v1.3.."`
+}
+
+func (pl *SignatureVerifyRequestPayload) Operation() kmip.Operation {
+	return kmip.OperationSignatureVerify
+}
+
+// Response for SignatureVerify operation.
+//
+// The response contains the Unique Identifier of the Managed Cryptographic Object used as the key and
+// the OPTIONAL data recovered from the signature (for those signature algorithms where data recovery
+// from the signature is supported). The validity of the signature is indicated by the Validity Indicator field.
+//
+// The success or failure of the operation is indicated by the Result Status (and if failure the Result Reason)
+// in the response header.
+type SignatureVerifyResponsePayload struct {
+	// The Unique Identifier of the Managed Cryptographic Object that is the key used for the verification operation.
+	UniqueIdentifier string
+	// An Enumeration object indicating whether the signature is valid, invalid, or unknown.
+	ValidityIndicator kmip.ValidityIndicator
+	// The OPTIONAL recovered data (as a Byte String) for those signature algorithms where data recovery from the signature is supported.
+	Data *[]byte
+	// Specifies the stream or by-parts value to be provided in subsequent calls to this operation for performing cryptographic operations.
+	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+}
+
+func (pl *SignatureVerifyResponsePayload) Operation() kmip.Operation {
+	return kmip.OperationSignatureVerify
+}


### PR DESCRIPTION
This PR adds support for [Sign](http://docs.oasis-open.org/kmip/spec/v1.4/os/kmip-spec-v1.4-os.html#_Toc490660871) and [SignatureVerify](http://docs.oasis-open.org/kmip/spec/v1.4/os/kmip-spec-v1.4-os.html#_Toc490660872) KMIP operations, for KMIP version `1.2`, `1.3` and `1.4`