### PR TITLE
refactor!: use omitempty instead of pointers where the zero value has no meaning

### DIFF
--- a/examples/encrypt_decrypt.go
+++ b/examples/encrypt_decrypt.go
@@ -26,8 +26,8 @@ func test_encrypt_decrypt_aes(client *kmipclient.Client) {
 		WithIvCounterNonce(iv).
 		WithAAD(aad).
 		WithCryptographicParameters(kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.AES),
-			BlockCipherMode:        ptrTo(kmip.GCM),
+			CryptographicAlgorithm: kmip.AES,
+			BlockCipherMode:        kmip.GCM,
 		}).
 		Data(plain).
 		MustExec()
@@ -36,10 +36,10 @@ func test_encrypt_decrypt_aes(client *kmipclient.Client) {
 		WithIvCounterNonce(iv).
 		WithAAD(aad).
 		WithCryptographicParameters(kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.AES),
-			BlockCipherMode:        ptrTo(kmip.GCM),
+			CryptographicAlgorithm: kmip.AES,
+			BlockCipherMode:        kmip.GCM,
 		}).
-		WithAuthTag(*resp.AuthenticatedEncryptionTag).
+		WithAuthTag(resp.AuthenticatedEncryptionTag).
 		Data(resp.Data).
 		MustExec()
 }
@@ -51,8 +51,8 @@ func test_encrypt_decrypt_aes_default(client *kmipclient.Client) {
 	keyId := client.Create().
 		AES(256, kmip.Encrypt|kmip.Decrypt).
 		WithAttribute(kmip.AttributeNameCryptographicParameters, kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.AES),
-			BlockCipherMode:        ptrTo(kmip.GCM),
+			CryptographicAlgorithm: kmip.AES,
+			BlockCipherMode:        kmip.GCM,
 			RandomIV:               ptrTo(true),
 		}).
 		MustExec().
@@ -66,9 +66,9 @@ func test_encrypt_decrypt_aes_default(client *kmipclient.Client) {
 		MustExec()
 
 	client.Decrypt(keyId).
-		WithIvCounterNonce(*resp.IVCounterNonce).
+		WithIvCounterNonce(resp.IVCounterNonce).
 		WithAAD(aad).
-		WithAuthTag(*resp.AuthenticatedEncryptionTag).
+		WithAuthTag(resp.AuthenticatedEncryptionTag).
 		Data(resp.Data).
 		MustExec()
 }
@@ -85,14 +85,14 @@ func test_encrypt_encrypt_aes_cbc_pkcs5(client *kmipclient.Client) {
 	_, _ = rand.Reader.Read(iv)
 
 	respPl, err := client.Request(context.Background(), &payloads.EncryptRequestPayload{
-		UniqueIdentifier: &keyId,
+		UniqueIdentifier: keyId,
 		Data:             []byte("Hello World!"),
 		CryptographicParameters: &kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.AES),
-			BlockCipherMode:        ptrTo(kmip.CBC),
-			PaddingMethod:          ptrTo(kmip.PKCS5),
+			CryptographicAlgorithm: kmip.AES,
+			BlockCipherMode:        kmip.CBC,
+			PaddingMethod:          kmip.PKCS5,
 		},
-		IVCounterNonce: ptrTo(iv),
+		IVCounterNonce: iv,
 	})
 	if err != nil {
 		panic(err)
@@ -100,12 +100,12 @@ func test_encrypt_encrypt_aes_cbc_pkcs5(client *kmipclient.Client) {
 	resp := respPl.(*payloads.EncryptResponsePayload)
 
 	respD, err := client.Request(context.Background(), &payloads.DecryptRequestPayload{
-		UniqueIdentifier: &keyId,
+		UniqueIdentifier: keyId,
 		Data:             resp.Data,
 		CryptographicParameters: &kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.AES),
-			BlockCipherMode:        ptrTo(kmip.CBC),
-			PaddingMethod:          ptrTo(kmip.PKCS5),
+			CryptographicAlgorithm: kmip.AES,
+			BlockCipherMode:        kmip.CBC,
+			PaddingMethod:          kmip.PKCS5,
 		},
 		IVCounterNonce: resp.IVCounterNonce,
 	})
@@ -124,12 +124,12 @@ func test_encrypt_decrypt_rsa_oaep(client *kmipclient.Client) {
 		MustExec()
 
 	respPl, err := client.Request(context.Background(), &payloads.EncryptRequestPayload{
-		UniqueIdentifier: &key.PublicKeyUniqueIdentifier,
+		UniqueIdentifier: key.PublicKeyUniqueIdentifier,
 		Data:             []byte("Hello World!"),
 		CryptographicParameters: &kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.RSA),
-			PaddingMethod:          ptrTo(kmip.OAEP),
-			HashingAlgorithm:       ptrTo(kmip.SHA_256),
+			CryptographicAlgorithm: kmip.RSA,
+			PaddingMethod:          kmip.OAEP,
+			HashingAlgorithm:       kmip.SHA_256,
 		},
 	})
 	if err != nil {
@@ -138,12 +138,12 @@ func test_encrypt_decrypt_rsa_oaep(client *kmipclient.Client) {
 	resp := respPl.(*payloads.EncryptResponsePayload)
 
 	_, err = client.Request(context.Background(), &payloads.DecryptRequestPayload{
-		UniqueIdentifier: &key.PrivateKeyUniqueIdentifier,
+		UniqueIdentifier: key.PrivateKeyUniqueIdentifier,
 		Data:             resp.Data,
 		CryptographicParameters: &kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.RSA),
-			PaddingMethod:          ptrTo(kmip.OAEP),
-			HashingAlgorithm:       ptrTo(kmip.SHA_256),
+			CryptographicAlgorithm: kmip.RSA,
+			PaddingMethod:          kmip.OAEP,
+			HashingAlgorithm:       kmip.SHA_256,
 		},
 	})
 	if err != nil {
@@ -158,11 +158,11 @@ func test_encrypt_decrypt_rsa_pkcs1(client *kmipclient.Client) {
 		MustExec()
 
 	respPl, err := client.Request(context.Background(), &payloads.EncryptRequestPayload{
-		UniqueIdentifier: &key.PublicKeyUniqueIdentifier,
+		UniqueIdentifier: key.PublicKeyUniqueIdentifier,
 		Data:             []byte("Hello World!"),
 		CryptographicParameters: &kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.RSA),
-			PaddingMethod:          ptrTo(kmip.PKCS1V1_5),
+			CryptographicAlgorithm: kmip.RSA,
+			PaddingMethod:          kmip.PKCS1V1_5,
 		},
 	})
 	if err != nil {
@@ -171,11 +171,11 @@ func test_encrypt_decrypt_rsa_pkcs1(client *kmipclient.Client) {
 	resp := respPl.(*payloads.EncryptResponsePayload)
 
 	_, err = client.Request(context.Background(), &payloads.DecryptRequestPayload{
-		UniqueIdentifier: &key.PrivateKeyUniqueIdentifier,
+		UniqueIdentifier: key.PrivateKeyUniqueIdentifier,
 		Data:             resp.Data,
 		CryptographicParameters: &kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.RSA),
-			PaddingMethod:          ptrTo(kmip.PKCS1V1_5),
+			CryptographicAlgorithm: kmip.RSA,
+			PaddingMethod:          kmip.PKCS1V1_5,
 		},
 	})
 	if err != nil {
@@ -192,14 +192,14 @@ func test_encrypt_decrypt_aes_with_usage(client *kmipclient.Client) {
 	client.Activate(keyId).MustExec()
 
 	respPl, err := client.Request(context.Background(), &payloads.EncryptRequestPayload{
-		UniqueIdentifier: &keyId,
+		UniqueIdentifier: keyId,
 		Data:             []byte("Hello World!"),
 		CryptographicParameters: &kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.AES),
-			BlockCipherMode:        ptrTo(kmip.GCM),
+			CryptographicAlgorithm: kmip.AES,
+			BlockCipherMode:        kmip.GCM,
 		},
-		IVCounterNonce:                        ptrTo([]byte("abcdefghijkl")),
-		AuthenticatedEncryptionAdditionalData: ptrTo([]byte("toto")),
+		IVCounterNonce:                        []byte("abcdefghijkl"),
+		AuthenticatedEncryptionAdditionalData: []byte("toto"),
 	})
 	if err != nil {
 		panic(err)
@@ -207,15 +207,15 @@ func test_encrypt_decrypt_aes_with_usage(client *kmipclient.Client) {
 	resp := respPl.(*payloads.EncryptResponsePayload)
 
 	_, err = client.Request(context.Background(), &payloads.DecryptRequestPayload{
-		UniqueIdentifier: &keyId,
+		UniqueIdentifier: keyId,
 		Data:             resp.Data,
 		CryptographicParameters: &kmip.CryptographicParameters{
-			CryptographicAlgorithm: ptrTo(kmip.AES),
-			BlockCipherMode:        ptrTo(kmip.GCM),
+			CryptographicAlgorithm: kmip.AES,
+			BlockCipherMode:        kmip.GCM,
 		},
 		IVCounterNonce:                        resp.IVCounterNonce,
 		AuthenticatedEncryptionTag:            resp.AuthenticatedEncryptionTag,
-		AuthenticatedEncryptionAdditionalData: ptrTo([]byte("toto")),
+		AuthenticatedEncryptionAdditionalData: []byte("toto"),
 	})
 	if err != nil {
 		panic(err)

--- a/examples/main.go
+++ b/examples/main.go
@@ -292,8 +292,8 @@ func register_split_key(client *kmipclient.Client) {
 		SplitKeyMethod:    kmip.SplitKeyMethodXOR,
 		KeyBlock: kmip.KeyBlock{
 			KeyFormatType:          kmip.KeyFormatRaw,
-			CryptographicAlgorithm: &alg,  // FIXME: If alg is null, Internal server error
-			CryptographicLength:    &clen, // FIXME: Same here
+			CryptographicAlgorithm: alg,  // FIXME: If alg is null, Internal server error
+			CryptographicLength:    clen, // FIXME: Same here
 			KeyValue: &kmip.KeyValue{
 				Plain: &kmip.PlainKeyValue{
 					KeyMaterial: kmip.KeyMaterial{Bytes: &[]byte{1, 2, 3, 4}},
@@ -337,7 +337,7 @@ func register_pgp(client *kmipclient.Client) {
 	clen := int32(2048)
 	client.Register().Object(&kmip.PGPKey{
 		PGPKeyVersion: 12,
-		KeyBlock:      kmip.KeyBlock{KeyFormatType: kmip.KeyFormatRaw, CryptographicAlgorithm: &alg, CryptographicLength: &clen, KeyValue: &kmip.KeyValue{Plain: &kmip.PlainKeyValue{KeyMaterial: kmip.KeyMaterial{Bytes: &key}}}},
+		KeyBlock:      kmip.KeyBlock{KeyFormatType: kmip.KeyFormatRaw, CryptographicAlgorithm: alg, CryptographicLength: clen, KeyValue: &kmip.KeyValue{Plain: &kmip.PlainKeyValue{KeyMaterial: kmip.KeyMaterial{Bytes: &key}}}},
 	}).WithAttribute(kmip.AttributeNameCryptographicUsageMask, kmip.Sign|kmip.Verify).MustExec()
 }
 
@@ -464,8 +464,8 @@ func test_register_ecdsa_wrong_alg(client *kmipclient.Client) {
 						},
 					},
 				},
-				CryptographicAlgorithm: &alg,
-				CryptographicLength:    &clen,
+				CryptographicAlgorithm: alg,
+				CryptographicLength:    clen,
 			},
 		}).
 		WithAttribute(kmip.AttributeNameCryptographicUsageMask, kmip.Sign|kmip.Verify).
@@ -615,14 +615,14 @@ func test_get_unsupported_wrapped_key(client *kmipclient.Client) {
 		MustExec()
 
 	req := payloads.GetRequestPayload{
-		UniqueIdentifier: &res.UniqueIdentifier,
+		UniqueIdentifier: res.UniqueIdentifier,
 		KeyWrappingSpecification: &kmip.KeyWrappingSpecification{
 			WrappingMethod: kmip.WrappingMethodEncrypt,
 			EncryptionKeyInformation: &kmip.EncryptionKeyInformation{
 				UniqueIdentifier: wrapKey.UniqueIdentifier,
 				CryptographicParameters: &kmip.CryptographicParameters{
-					BlockCipherMode:        ptrTo(kmip.AESKeyWrapPadding),
-					CryptographicAlgorithm: ptrTo(kmip.AES),
+					BlockCipherMode:        kmip.AESKeyWrapPadding,
+					CryptographicAlgorithm: kmip.AES,
 				},
 			},
 		},
@@ -645,8 +645,8 @@ func test_get_register_wrapped_aes_key(client *kmipclient.Client) {
 		EncryptionKeyInformation: &kmip.EncryptionKeyInformation{
 			UniqueIdentifier: wrapKey.UniqueIdentifier,
 			CryptographicParameters: &kmip.CryptographicParameters{
-				BlockCipherMode:        ptrTo(kmip.NISTKeyWrap),
-				CryptographicAlgorithm: ptrTo(kmip.AES),
+				BlockCipherMode:        kmip.NISTKeyWrap,
+				CryptographicAlgorithm: kmip.AES,
 			},
 		},
 	}).MustExec()
@@ -666,8 +666,8 @@ func test_get_register_wrapped_rsa_key(client *kmipclient.Client) {
 		EncryptionKeyInformation: &kmip.EncryptionKeyInformation{
 			UniqueIdentifier: wrapKey.UniqueIdentifier,
 			CryptographicParameters: &kmip.CryptographicParameters{
-				BlockCipherMode:        ptrTo(kmip.NISTKeyWrap),
-				CryptographicAlgorithm: ptrTo(kmip.AES),
+				BlockCipherMode:        kmip.NISTKeyWrap,
+				CryptographicAlgorithm: kmip.AES,
 			},
 		},
 	}).MustExec()
@@ -687,8 +687,8 @@ func test_get_register_wrapped_ecdsa_key(client *kmipclient.Client) {
 		EncryptionKeyInformation: &kmip.EncryptionKeyInformation{
 			UniqueIdentifier: wrapKey.UniqueIdentifier,
 			CryptographicParameters: &kmip.CryptographicParameters{
-				BlockCipherMode:        ptrTo(kmip.NISTKeyWrap),
-				CryptographicAlgorithm: ptrTo(kmip.AES),
+				BlockCipherMode:        kmip.NISTKeyWrap,
+				CryptographicAlgorithm: kmip.AES,
 			},
 		},
 	}).MustExec()

--- a/examples/sign_verify.go
+++ b/examples/sign_verify.go
@@ -8,7 +8,7 @@ import (
 func test_sign_verify_rsa(client *kmipclient.Client) {
 	data := []byte("foobarbaz")
 	cparams := kmip.CryptographicParameters{
-		DigitalSignatureAlgorithm: ptrTo(kmip.SHA_256WithRSAEncryptionPKCS_1v1_5),
+		DigitalSignatureAlgorithm: kmip.SHA_256WithRSAEncryptionPKCS_1v1_5,
 	}
 
 	key := client.CreateKeyPair().RSA(2048, kmip.Sign, kmip.Verify).
@@ -24,6 +24,6 @@ func test_sign_verify_rsa(client *kmipclient.Client) {
 	client.SignatureVerify(key.PublicKeyUniqueIdentifier).
 		WithCryptographicParameters(cparams).
 		Data(data).
-		Signature(*resp.SignatureData).
+		Signature(resp.SignatureData).
 		MustExec()
 }

--- a/kmip.go
+++ b/kmip.go
@@ -60,23 +60,23 @@ func (cred *CredentialValue) decode(d *ttlv.Decoder, tag int, cType CredentialTy
 
 type CredentialValueUserPassword struct {
 	Username string
-	Password *string
+	Password string `ttlv:",omitempty"`
 }
 
 type CredentialValueDevice struct {
-	DeviceSerialNumber *string
-	Password           *string
-	DeviceIdentifier   *string
-	NetworkIdentifier  *string
-	MachineIdentifier  *string
-	MediaIdentifier    *string
+	DeviceSerialNumber string `ttlv:",omitempty"`
+	Password           string `ttlv:",omitempty"`
+	DeviceIdentifier   string `ttlv:",omitempty"`
+	NetworkIdentifier  string `ttlv:",omitempty"`
+	MachineIdentifier  string `ttlv:",omitempty"`
+	MediaIdentifier    string `ttlv:",omitempty"`
 }
 
 type CredentialValueAttestation struct {
 	Nonce                  Nonce
 	AttestationType        AttestationType
-	AttestationMeasurement *[]byte
-	AttestationAssertion   *[]byte
+	AttestationMeasurement []byte `ttlv:",omitempty"`
+	AttestationAssertion   []byte `ttlv:",omitempty"`
 }
 
 type Credential struct {
@@ -101,7 +101,7 @@ type Authentication struct {
 
 type RevocationReason struct {
 	RevocationReasonCode RevocationReasonCode `ttlv:",omitempty"`
-	RevocationMessage    *string
+	RevocationMessage    string               `ttlv:",omitempty"`
 }
 
 type MessageExtension struct {
@@ -111,31 +111,31 @@ type MessageExtension struct {
 }
 
 type CryptographicParameters struct {
-	BlockCipherMode  *BlockCipherMode
-	PaddingMethod    *PaddingMethod
-	HashingAlgorithm *HashingAlgorithm
-	KeyRoleType      *KeyRoleType
+	BlockCipherMode  BlockCipherMode  `ttlv:",omitempty"`
+	PaddingMethod    PaddingMethod    `ttlv:",omitempty"`
+	HashingAlgorithm HashingAlgorithm `ttlv:",omitempty"`
+	KeyRoleType      KeyRoleType      `ttlv:",omitempty"`
 
-	DigitalSignatureAlgorithm *DigitalSignatureAlgorithm `ttlv:",version=v1.2.."`
-	CryptographicAlgorithm    *CryptographicAlgorithm    `ttlv:",version=v1.2.."`
-	RandomIV                  *bool                      `ttlv:",version=v1.2.."`
-	IVLength                  *int32                     `ttlv:",version=v1.2.."`
-	TagLength                 *int32                     `ttlv:",version=v1.2.."`
-	FixedFieldLength          *int32                     `ttlv:",version=v1.2.."`
-	InvocationFieldLength     *int32                     `ttlv:",version=v1.2.."`
-	CounterLength             *int32                     `ttlv:",version=v1.2.."`
-	InitialCounterValue       *int32                     `ttlv:",version=v1.2.."`
+	DigitalSignatureAlgorithm DigitalSignatureAlgorithm `ttlv:",omitempty,version=v1.2.."`
+	CryptographicAlgorithm    CryptographicAlgorithm    `ttlv:",omitempty,version=v1.2.."`
+	RandomIV                  *bool                     `ttlv:",version=v1.2.."`
+	IVLength                  int32                     `ttlv:",omitempty,version=v1.2.."`
+	TagLength                 int32                     `ttlv:",omitempty,version=v1.2.."`
+	FixedFieldLength          int32                     `ttlv:",omitempty,version=v1.2.."`
+	InvocationFieldLength     int32                     `ttlv:",omitempty,version=v1.2.."`
+	CounterLength             int32                     `ttlv:",omitempty,version=v1.2.."`
+	InitialCounterValue       *int32                    `ttlv:",version=v1.2.."`
 
-	SaltLength                    *int32            `ttlv:",version=v1.4.."`
-	MaskGenerator                 *MaskGenerator    `ttlv:",version=v1.4.."`
-	MaskGeneratorHashingAlgorithm *HashingAlgorithm `ttlv:",version=v1.4.."`
-	PSource                       *[]byte           `ttlv:",version=v1.4.."`
-	TrailerField                  *int32            `ttlv:",version=v1.4.."`
+	SaltLength                    int32            `ttlv:",omitempty,version=v1.4.."`
+	MaskGenerator                 MaskGenerator    `ttlv:",omitempty,version=v1.4.."`
+	MaskGeneratorHashingAlgorithm HashingAlgorithm `ttlv:",omitempty,version=v1.4.."`
+	PSource                       []byte           `ttlv:",omitempty,version=v1.4.."`
+	TrailerField                  *int32           `ttlv:",version=v1.4.."`
 }
 
 type CryptographicDomainParameters struct {
-	Qlength          *int32
-	RecommendedCurve *RecommendedCurve
+	Qlength          int32            `ttlv:",omitempty"`
+	RecommendedCurve RecommendedCurve `ttlv:",omitempty"`
 }
 
 type KeyWrappingSpecification struct {
@@ -143,7 +143,7 @@ type KeyWrappingSpecification struct {
 	EncryptionKeyInformation   *EncryptionKeyInformation
 	MACSignatureKeyInformation *MACSignatureKeyInformation
 	AttributeName              []AttributeName
-	EncodingOption             *EncodingOption `ttlv:",version=v1.1.."`
+	EncodingOption             EncodingOption `ttlv:",omitempty,version=v1.1.."`
 }
 
 type Link struct {
@@ -154,13 +154,13 @@ type Link struct {
 type Digest struct {
 	HashingAlgorithm HashingAlgorithm
 	DigestValue      []byte
-	KeyFormatType    *KeyFormatType `ttlv:",version=1.1.."`
+	KeyFormatType    KeyFormatType `ttlv:",omitempty,version=1.1.."`
 }
 
 // Deprecated: deprecated as of kmip 1.1.
 type CertificateIdentifier struct {
 	Issuer       string `ttlv:",omitempty"`
-	SerialNumber *string
+	SerialNumber string `ttlv:",omitempty"`
 }
 
 // Deprecated: deprecated as of kmip 1.1.
@@ -198,8 +198,8 @@ func (ul UsageLimits) Equals(other *UsageLimits) bool {
 
 type ExtensionInformation struct {
 	ExtensionName string
-	ExtensionTag  *int32
-	ExtensionType *int32
+	ExtensionTag  int32 `ttlv:",omitempty"`
+	ExtensionType int32 `ttlv:",omitempty"`
 }
 
 type X_509CertificateIdentifier struct {
@@ -237,33 +237,33 @@ type KeyValueLocation struct {
 // KMIP 1.3.
 
 type RNGParameters struct {
-	RNGAlgorithm           RNGAlgorithm `ttlv:",omitempty"`
-	CryptographicAlgorithm *CryptographicAlgorithm
-	CryptographicLength    *int32
-	HashingAlgorithm       *HashingAlgorithm
-	DRBGAlgorithm          *DRBGAlgorithm
-	RecommendedCurve       *RecommendedCurve
-	FIPS186Variation       *FIPS186Variation
+	RNGAlgorithm           RNGAlgorithm           `ttlv:",omitempty"`
+	CryptographicAlgorithm CryptographicAlgorithm `ttlv:",omitempty"`
+	CryptographicLength    int32                  `ttlv:",omitempty"`
+	HashingAlgorithm       HashingAlgorithm       `ttlv:",omitempty"`
+	DRBGAlgorithm          DRBGAlgorithm          `ttlv:",omitempty"`
+	RecommendedCurve       RecommendedCurve       `ttlv:",omitempty"`
+	FIPS186Variation       FIPS186Variation       `ttlv:",omitempty"`
 	PredictionResistance   *bool
 }
 
 type ProfileInformation struct {
 	ProfileName ProfileName
-	ServerURI   *string
-	ServerPort  *int32
+	ServerURI   string `ttlv:",omitempty"`
+	ServerPort  int32  `ttlv:",omitempty"`
 }
 
 type ValidationInformation struct {
 	ValidationAuthorityType         ValidationAuthorityType
-	ValidationAuthorityCountry      *string
-	ValidationAuthorityURI          *string
+	ValidationAuthorityCountry      string `ttlv:",omitempty"`
+	ValidationAuthorityURI          string `ttlv:",omitempty"`
 	ValidationVersionMajor          int32
 	ValidationVersionMinor          *int32
 	ValidationType                  ValidationType
 	ValidationLevel                 int32
-	ValidationCertificateIdentifier *string
-	ValidationCertificateURI        *string
-	ValidationVendorURI             *string
+	ValidationCertificateIdentifier string `ttlv:",omitempty"`
+	ValidationCertificateURI        string `ttlv:",omitempty"`
+	ValidationVendorURI             string `ttlv:",omitempty"`
 	ValidationProfile               []string
 }
 
@@ -271,10 +271,10 @@ type CapabilityInformation struct {
 	StreamingCapability     *bool
 	AsynchronousCapability  *bool
 	AttestationCapability   *bool
-	BatchUndoCapability     *bool `ttlv:",version=v1.4.."`
-	BatchContinueCapability *bool `ttlv:",version=v1.4.."`
-	UnwrapMode              *UnwrapMode
-	DestroyAction           *DestroyAction
-	ShreddingAlgorithm      *ShreddingAlgorithm
-	RNGMode                 *RNGMode
+	BatchUndoCapability     *bool              `ttlv:",version=v1.4.."`
+	BatchContinueCapability *bool              `ttlv:",version=v1.4.."`
+	UnwrapMode              UnwrapMode         `ttlv:",omitempty"`
+	DestroyAction           DestroyAction      `ttlv:",omitempty"`
+	ShreddingAlgorithm      ShreddingAlgorithm `ttlv:",omitempty"`
+	RNGMode                 RNGMode            `ttlv:",omitempty"`
 }

--- a/kmipclient/activate.go
+++ b/kmipclient/activate.go
@@ -8,7 +8,7 @@ func (c *Client) Activate(id string) ExecActivate {
 	return ExecActivate{
 		client: c,
 		req: &payloads.ActivateRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }

--- a/kmipclient/add_attribute.go
+++ b/kmipclient/add_attribute.go
@@ -10,7 +10,7 @@ func (c *Client) AddAttribute(id string, name kmip.AttributeName, value any) Exe
 		Executor[*payloads.AddAttributeRequestPayload, *payloads.AddAttributeResponsePayload]{
 			client: c,
 			req: &payloads.AddAttributeRequestPayload{
-				UniqueIdentifier: &id,
+				UniqueIdentifier: id,
 				Attribute:        kmip.Attribute{AttributeName: name, AttributeValue: value},
 			},
 		},

--- a/kmipclient/archive_recover.go
+++ b/kmipclient/archive_recover.go
@@ -8,7 +8,7 @@ func (c *Client) Archive(id string) ExecArchive {
 	return ExecArchive{
 		client: c,
 		req: &payloads.ArchiveRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }
@@ -19,7 +19,7 @@ func (c *Client) Recover(id string) ExecRecover {
 	return ExecRecover{
 		client: c,
 		req: &payloads.RecoverRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }

--- a/kmipclient/client_test.go
+++ b/kmipclient/client_test.go
@@ -63,7 +63,7 @@ func TestActivate(t *testing.T) {
 	req := client.Activate("foobar")
 	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(func(ctx context.Context, pl *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
 		require.EqualValues(t, req.RequestPayload(), pl)
-		return &payloads.ActivateResponsePayload{UniqueIdentifier: *pl.UniqueIdentifier}, nil
+		return &payloads.ActivateResponsePayload{UniqueIdentifier: pl.UniqueIdentifier}, nil
 	}))
 	resp, err := req.Exec()
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestAddAttribute(t *testing.T) {
 	req := client.AddAttribute("foobar", kmip.AttributeNameName, kmip.Name{NameValue: "foo", NameType: kmip.UninterpretedTextString})
 	mux.Route(kmip.OperationAddAttribute, kmipserver.HandleFunc(func(ctx context.Context, pl *payloads.AddAttributeRequestPayload) (*payloads.AddAttributeResponsePayload, error) {
 		require.EqualValues(t, req.RequestPayload(), pl)
-		return &payloads.AddAttributeResponsePayload{UniqueIdentifier: *pl.UniqueIdentifier, Attribute: pl.Attribute}, nil
+		return &payloads.AddAttributeResponsePayload{UniqueIdentifier: pl.UniqueIdentifier, Attribute: pl.Attribute}, nil
 	}))
 	resp, err := req.Exec()
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestAddAttribute(t *testing.T) {
 	req = req.WithIndex(12)
 	mux.Route(kmip.OperationAddAttribute, kmipserver.HandleFunc(func(ctx context.Context, pl *payloads.AddAttributeRequestPayload) (*payloads.AddAttributeResponsePayload, error) {
 		require.EqualValues(t, req.RequestPayload(), pl)
-		return &payloads.AddAttributeResponsePayload{UniqueIdentifier: *pl.UniqueIdentifier, Attribute: pl.Attribute}, nil
+		return &payloads.AddAttributeResponsePayload{UniqueIdentifier: pl.UniqueIdentifier, Attribute: pl.Attribute}, nil
 	}))
 	resp, err = req.Exec()
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestArchive(t *testing.T) {
 	req := client.Archive("foobar")
 	mux.Route(kmip.OperationArchive, kmipserver.HandleFunc(func(ctx context.Context, pl *payloads.ArchiveRequestPayload) (*payloads.ArchiveResponsePayload, error) {
 		require.EqualValues(t, req.RequestPayload(), pl)
-		return &payloads.ArchiveResponsePayload{UniqueIdentifier: *pl.UniqueIdentifier}, nil
+		return &payloads.ArchiveResponsePayload{UniqueIdentifier: pl.UniqueIdentifier}, nil
 	}))
 	resp, err := req.Exec()
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestRecover(t *testing.T) {
 	req := client.Recover("foobar")
 	mux.Route(kmip.OperationRecover, kmipserver.HandleFunc(func(ctx context.Context, pl *payloads.RecoverRequestPayload) (*payloads.RecoverResponsePayload, error) {
 		require.EqualValues(t, req.RequestPayload(), pl)
-		return &payloads.RecoverResponsePayload{UniqueIdentifier: *pl.UniqueIdentifier}, nil
+		return &payloads.RecoverResponsePayload{UniqueIdentifier: pl.UniqueIdentifier}, nil
 	}))
 	resp, err := req.Exec()
 	require.NoError(t, err)
@@ -191,11 +191,11 @@ func TestRekey(t *testing.T) {
 
 	mux.Route(kmip.OperationReKey, kmipserver.HandleFunc(func(ctx context.Context, pl *payloads.RekeyRequestPayload) (*payloads.RekeyResponsePayload, error) {
 		require.EqualValues(t, req.RequestPayload(), pl)
-		return &payloads.RekeyResponsePayload{UniqueIdentifier: *pl.UniqueIdentifier}, nil
+		return &payloads.RekeyResponsePayload{UniqueIdentifier: pl.UniqueIdentifier}, nil
 	}))
 
 	resp := req.MustExec()
-	require.EqualValues(t, *req.RequestPayload().UniqueIdentifier, resp.UniqueIdentifier)
+	require.EqualValues(t, req.RequestPayload().UniqueIdentifier, resp.UniqueIdentifier)
 }
 
 func TestClone(t *testing.T) {

--- a/kmipclient/create_keypair.go
+++ b/kmipclient/create_keypair.go
@@ -35,7 +35,7 @@ func (ex ExecCreateKeyPair) ECDSA(curve kmip.RecommendedCurve, privateUsage, pub
 	return ex.Common().
 		WithAttribute(kmip.AttributeNameCryptographicAlgorithm, kmip.ECDSA).
 		WithAttribute(kmip.AttributeNameCryptographicLength, curve.Bitlen()).
-		WithAttribute(kmip.AttributeNameCryptographicDomainParameters, kmip.CryptographicDomainParameters{RecommendedCurve: &curve}).
+		WithAttribute(kmip.AttributeNameCryptographicDomainParameters, kmip.CryptographicDomainParameters{RecommendedCurve: curve}).
 		PublicKey().WithAttribute(kmip.AttributeNameCryptographicUsageMask, publicUsage).
 		PrivateKey().WithAttribute(kmip.AttributeNameCryptographicUsageMask, privateUsage).
 		Common()

--- a/kmipclient/delete_attribute.go
+++ b/kmipclient/delete_attribute.go
@@ -10,7 +10,7 @@ func (c *Client) DeleteAttribute(id string, name kmip.AttributeName) ExecDeleteA
 		Executor[*payloads.DeleteAttributeRequestPayload, *payloads.DeleteAttributeResponsePayload]{
 			client: c,
 			req: &payloads.DeleteAttributeRequestPayload{
-				UniqueIdentifier: &id,
+				UniqueIdentifier: id,
 				AttributeName:    name,
 			},
 		},

--- a/kmipclient/destroy.go
+++ b/kmipclient/destroy.go
@@ -8,7 +8,7 @@ func (c *Client) Destroy(id string) ExecDestroy {
 	return ExecDestroy{
 		client: c,
 		req: &payloads.DestroyRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }

--- a/kmipclient/encrypt_decrypt.go
+++ b/kmipclient/encrypt_decrypt.go
@@ -27,18 +27,18 @@ func (c *Client) Encrypt(id string) ExecEncryptWantsData {
 	return ExecEncryptWantsData{
 		client: c,
 		req: &payloads.EncryptRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }
 
 func (ex ExecEncryptWantsData) WithIvCounterNonce(iv []byte) ExecEncryptWantsData {
-	ex.req.IVCounterNonce = &iv
+	ex.req.IVCounterNonce = iv
 	return ex
 }
 
 func (ex ExecEncryptWantsData) WithAAD(aad []byte) ExecEncryptWantsData {
-	ex.req.AuthenticatedEncryptionAdditionalData = &aad
+	ex.req.AuthenticatedEncryptionAdditionalData = aad
 	return ex
 }
 
@@ -61,18 +61,18 @@ func (c *Client) Decrypt(id string) ExecDecryptWantsData {
 	return ExecDecryptWantsData{
 		client: c,
 		req: &payloads.DecryptRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }
 
 func (ex ExecDecryptWantsData) WithIvCounterNonce(iv []byte) ExecDecryptWantsData {
-	ex.req.IVCounterNonce = &iv
+	ex.req.IVCounterNonce = iv
 	return ex
 }
 
 func (ex ExecDecryptWantsData) WithAAD(aad []byte) ExecDecryptWantsData {
-	ex.req.AuthenticatedEncryptionAdditionalData = &aad
+	ex.req.AuthenticatedEncryptionAdditionalData = aad
 	return ex
 }
 
@@ -82,7 +82,7 @@ func (ex ExecDecryptWantsData) WithCryptographicParameters(params kmip.Cryptogra
 }
 
 func (ex ExecDecryptWantsData) WithAuthTag(tag []byte) ExecDecryptWantsData {
-	ex.req.AuthenticatedEncryptionTag = &tag
+	ex.req.AuthenticatedEncryptionTag = tag
 	return ex
 }
 

--- a/kmipclient/get.go
+++ b/kmipclient/get.go
@@ -10,7 +10,7 @@ func (c *Client) Get(id string) ExecGet {
 		Executor[*payloads.GetRequestPayload, *payloads.GetResponsePayload]{
 			client: c,
 			req: &payloads.GetRequestPayload{
-				UniqueIdentifier: &id,
+				UniqueIdentifier: id,
 			},
 		},
 	}
@@ -21,17 +21,17 @@ type ExecGet struct {
 }
 
 func (ex ExecGet) WithKeyFormat(format kmip.KeyFormatType) ExecGet {
-	ex.req.KeyFormatType = &format
+	ex.req.KeyFormatType = format
 	return ex
 }
 
 func (ex ExecGet) WithKeyWrapType(format kmip.KeyFormatType) ExecGet {
-	ex.req.KeyWrapType = &format
+	ex.req.KeyWrapType = format
 	return ex
 }
 
 func (ex ExecGet) WithKeyCompression(compression kmip.KeyCompressionType) ExecGet {
-	ex.req.KeyCompressionType = &compression
+	ex.req.KeyCompressionType = compression
 	return ex
 }
 

--- a/kmipclient/get_attribute_list.go
+++ b/kmipclient/get_attribute_list.go
@@ -6,7 +6,7 @@ func (c *Client) GetAttributeList(id string) ExecGetAttributeList {
 	return ExecGetAttributeList{
 		client: c,
 		req: &payloads.GetAttributeListRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }

--- a/kmipclient/get_attributes.go
+++ b/kmipclient/get_attributes.go
@@ -10,7 +10,7 @@ func (c *Client) GetAttributes(id string, attributes ...kmip.AttributeName) Exec
 		Executor[*payloads.GetAttributesRequestPayload, *payloads.GetAttributesResponsePayload]{
 			client: c,
 			req: &payloads.GetAttributesRequestPayload{
-				UniqueIdentifier: &id,
+				UniqueIdentifier: id,
 			},
 		},
 	}.WithAttributes(attributes...)

--- a/kmipclient/get_usage.go
+++ b/kmipclient/get_usage.go
@@ -6,7 +6,7 @@ func (c *Client) GetUsageAllocation(id string, limitCount int64) ExecGetUsageAll
 	return ExecGetUsageAllocation{
 		client: c,
 		req: &payloads.GetUsageAllocationRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 			UsageLimitsCount: limitCount,
 		},
 	}

--- a/kmipclient/locate.go
+++ b/kmipclient/locate.go
@@ -27,21 +27,21 @@ type ExecLocate struct {
 }
 
 func (ex ExecLocate) WithStorageStatusMask(mask kmip.StorageStatusMask) ExecLocate {
-	ex.req.StorageStatusMask = &mask
+	ex.req.StorageStatusMask = mask
 	return ex
 }
 
 func (ex ExecLocate) WithMaxItems(maximum int32) ExecLocate {
-	ex.req.MaximumItems = &maximum
+	ex.req.MaximumItems = maximum
 	return ex
 }
 
 func (ex ExecLocate) WithOffset(offset int32) ExecLocate {
-	ex.req.OffsetItems = &offset
+	ex.req.OffsetItems = offset
 	return ex
 }
 
 func (ex ExecLocate) WithObjectGroupMember(groupMember kmip.ObjectGroupMember) ExecLocate {
-	ex.req.ObjectGroupMember = &groupMember
+	ex.req.ObjectGroupMember = groupMember
 	return ex
 }

--- a/kmipclient/middlewares.go
+++ b/kmipclient/middlewares.go
@@ -39,9 +39,8 @@ func CorrelationValueMiddleware(fn func() string) Middleware {
 		panic("correlation value generator function cannot be null")
 	}
 	return func(next Next, ctx context.Context, msg *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
-		if msg.Header.ClientCorrelationValue == nil && ttlv.CompareVersions(msg.Header.ProtocolVersion, kmip.V1_4) >= 0 {
-			corrVal := fn()
-			msg.Header.ClientCorrelationValue = &corrVal
+		if msg.Header.ClientCorrelationValue == "" && ttlv.CompareVersions(msg.Header.ProtocolVersion, kmip.V1_4) >= 0 {
+			msg.Header.ClientCorrelationValue = fn()
 		}
 		return next(ctx, msg)
 	}

--- a/kmipclient/modify_attribute.go
+++ b/kmipclient/modify_attribute.go
@@ -10,7 +10,7 @@ func (c *Client) ModifyAttribute(id string, name kmip.AttributeName, value any) 
 		Executor[*payloads.ModifyAttributeRequestPayload, *payloads.ModifyAttributeResponsePayload]{
 			client: c,
 			req: &payloads.ModifyAttributeRequestPayload{
-				UniqueIdentifier: &id,
+				UniqueIdentifier: id,
 				Attribute:        kmip.Attribute{AttributeName: name, AttributeValue: value},
 			},
 		},

--- a/kmipclient/obtain_lease.go
+++ b/kmipclient/obtain_lease.go
@@ -6,7 +6,7 @@ func (c *Client) ObtainLease(id string) ExecObtainLease {
 	return ExecObtainLease{
 		client: c,
 		req: &payloads.ObtainLeaseRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }

--- a/kmipclient/register.go
+++ b/kmipclient/register.go
@@ -139,8 +139,8 @@ func (ex ExecRegisterWantType) SymmetricKey(alg kmip.CryptographicAlgorithm, usa
 	return ex.Object(&kmip.SymmetricKey{
 		KeyBlock: kmip.KeyBlock{
 			KeyFormatType:          keyFmt,
-			CryptographicAlgorithm: &alg,
-			CryptographicLength:    &bitLen,
+			CryptographicAlgorithm: alg,
+			CryptographicLength:    bitLen,
 			KeyValue: &kmip.KeyValue{
 				Plain: &kmip.PlainKeyValue{
 					KeyMaterial: material,
@@ -152,9 +152,9 @@ func (ex ExecRegisterWantType) SymmetricKey(alg kmip.CryptographicAlgorithm, usa
 
 func (ex ExecRegisterWantType) rawKeyBytes(private bool, der []byte, alg kmip.CryptographicAlgorithm, bitlen int32, format kmip.KeyFormatType, usage kmip.CryptographicUsageMask) ExecRegister {
 	kb := kmip.KeyBlock{
-		CryptographicAlgorithm: &alg,
+		CryptographicAlgorithm: alg,
 		KeyFormatType:          format,
-		CryptographicLength:    &bitlen,
+		CryptographicLength:    bitlen,
 		KeyValue: &kmip.KeyValue{
 			Plain: &kmip.PlainKeyValue{
 				KeyMaterial: kmip.KeyMaterial{
@@ -347,9 +347,9 @@ func (ex ExecRegisterWantType) RsaPrivateKey(key *rsa.PrivateKey, usage kmip.Cry
 	case Transparent:
 		pkey := &kmip.PrivateKey{
 			KeyBlock: kmip.KeyBlock{
-				CryptographicAlgorithm: &alg,
+				CryptographicAlgorithm: alg,
 				KeyFormatType:          kmip.KeyFormatTransparentRSAPrivateKey,
-				CryptographicLength:    &bitlen,
+				CryptographicLength:    bitlen,
 				KeyValue: &kmip.KeyValue{
 					Plain: &kmip.PlainKeyValue{
 						KeyMaterial: kmip.KeyMaterial{
@@ -389,9 +389,9 @@ func (ex ExecRegisterWantType) RsaPublicKey(key *rsa.PublicKey, usage kmip.Crypt
 	case Transparent:
 		pkey := &kmip.PublicKey{
 			KeyBlock: kmip.KeyBlock{
-				CryptographicAlgorithm: &alg,
+				CryptographicAlgorithm: alg,
 				KeyFormatType:          kmip.KeyFormatTransparentRSAPublicKey,
-				CryptographicLength:    &bitlen,
+				CryptographicLength:    bitlen,
 				KeyValue: &kmip.KeyValue{
 					Plain: &kmip.PlainKeyValue{
 						KeyMaterial: kmip.KeyMaterial{
@@ -450,9 +450,9 @@ func (ex ExecRegisterWantType) EcdsaPrivateKey(key *ecdsa.PrivateKey, usage kmip
 		}
 		pkey := &kmip.PrivateKey{
 			KeyBlock: kmip.KeyBlock{
-				CryptographicAlgorithm: &alg,
+				CryptographicAlgorithm: alg,
 				KeyFormatType:          keyFormat,
-				CryptographicLength:    &bitlen,
+				CryptographicLength:    bitlen,
 				KeyValue: &kmip.KeyValue{
 					Plain: &kmip.PlainKeyValue{
 						KeyMaterial: keyMaterial,
@@ -503,10 +503,10 @@ func (ex ExecRegisterWantType) EcdsaPublicKey(key *ecdsa.PublicKey, usage kmip.C
 		}
 		pkey := &kmip.PublicKey{
 			KeyBlock: kmip.KeyBlock{
-				CryptographicAlgorithm: &alg,
+				CryptographicAlgorithm: alg,
 				KeyFormatType:          keyFormat,
-				KeyCompressionType:     &compressionType,
-				CryptographicLength:    &bitlen,
+				KeyCompressionType:     compressionType,
+				CryptographicLength:    bitlen,
 				KeyValue: &kmip.KeyValue{
 					Plain: &kmip.PlainKeyValue{
 						KeyMaterial: keyMaterial,

--- a/kmipclient/register_test.go
+++ b/kmipclient/register_test.go
@@ -91,7 +91,7 @@ func TestRegister_Symmetric(t *testing.T) {
 				require.Equal(t, kmip.ObjectTypeSymmetricKey, pl.ObjectType)
 				k, ok := pl.Object.(*kmip.SymmetricKey)
 				require.True(t, ok, "Object is not a symmetric key")
-				require.Equal(t, kmip.AES, *k.KeyBlock.CryptographicAlgorithm)
+				require.Equal(t, kmip.AES, k.KeyBlock.CryptographicAlgorithm)
 				require.Equal(t, tc.kmipFmt, k.KeyBlock.KeyFormatType)
 				// pl.TemplateAttribute.
 				//TODO: Check attributes name and cryptographic usage mask
@@ -133,7 +133,7 @@ func TestRegister_PrivateKey_RSA(t *testing.T) {
 				require.Equal(t, kmip.ObjectTypePrivateKey, pl.ObjectType)
 				k, ok := pl.Object.(*kmip.PrivateKey)
 				require.True(t, ok, "Object is not a private key")
-				require.Equal(t, kmip.RSA, *k.KeyBlock.CryptographicAlgorithm)
+				require.Equal(t, kmip.RSA, k.KeyBlock.CryptographicAlgorithm)
 				require.Equal(t, tc.kmipFmt, k.KeyBlock.KeyFormatType)
 				// pl.TemplateAttribute.
 				//TODO: Check attributes name and cryptographic usage mask
@@ -183,7 +183,7 @@ func TestRegister_PrivateKey_ECDSA(t *testing.T) {
 				require.Equal(t, kmip.ObjectTypePrivateKey, pl.ObjectType)
 				k, ok := pl.Object.(*kmip.PrivateKey)
 				require.True(t, ok, "Object is not a private key")
-				require.Equal(t, kmip.ECDSA, *k.KeyBlock.CryptographicAlgorithm)
+				require.Equal(t, kmip.ECDSA, k.KeyBlock.CryptographicAlgorithm)
 				require.Equal(t, tc.kmipFmt, k.KeyBlock.KeyFormatType)
 				// pl.TemplateAttribute.
 				//TODO: Check attributes name and cryptographic usage mask
@@ -233,7 +233,7 @@ func TestRegister_PublicKey_RSA(t *testing.T) {
 				require.Equal(t, kmip.ObjectTypePublicKey, pl.ObjectType)
 				k, ok := pl.Object.(*kmip.PublicKey)
 				require.True(t, ok, "Object is not a public key")
-				require.Equal(t, kmip.RSA, *k.KeyBlock.CryptographicAlgorithm)
+				require.Equal(t, kmip.RSA, k.KeyBlock.CryptographicAlgorithm)
 				require.Equal(t, tc.kmipFmt, k.KeyBlock.KeyFormatType)
 				// pl.TemplateAttribute.
 				//TODO: Check attributes name and cryptographic usage mask
@@ -281,7 +281,7 @@ func TestRegister_PublicKey_ECDSA(t *testing.T) {
 				require.Equal(t, kmip.ObjectTypePublicKey, pl.ObjectType)
 				k, ok := pl.Object.(*kmip.PublicKey)
 				require.True(t, ok, "Object is not a public key")
-				require.Equal(t, kmip.ECDSA, *k.KeyBlock.CryptographicAlgorithm)
+				require.Equal(t, kmip.ECDSA, k.KeyBlock.CryptographicAlgorithm)
 				require.Equal(t, tc.kmipFmt, k.KeyBlock.KeyFormatType)
 				// pl.TemplateAttribute.
 				//TODO: Check attributes name and cryptographic usage mask

--- a/kmipclient/rekey.go
+++ b/kmipclient/rekey.go
@@ -13,7 +13,7 @@ func (c *Client) Rekey(id string) ExecRekey {
 			Executor[*payloads.RekeyRequestPayload, *payloads.RekeyResponsePayload]{
 				client: c,
 				req: &payloads.RekeyRequestPayload{
-					UniqueIdentifier:  &id,
+					UniqueIdentifier:  id,
 					TemplateAttribute: &kmip.TemplateAttribute{},
 				},
 			},

--- a/kmipclient/revoke.go
+++ b/kmipclient/revoke.go
@@ -12,7 +12,7 @@ func (c *Client) Revoke(id string) ExecRevoke {
 		Executor[*payloads.RevokeRequestPayload, *payloads.RevokeResponsePayload]{
 			client: c,
 			req: &payloads.RevokeRequestPayload{
-				UniqueIdentifier: &id,
+				UniqueIdentifier: id,
 				RevocationReason: kmip.RevocationReason{
 					RevocationReasonCode: kmip.RevocationReasonCodeUnspecified,
 				},
@@ -32,7 +32,7 @@ func (ex ExecRevoke) WithRevocationReasonCode(code kmip.RevocationReasonCode) Ex
 
 func (ex ExecRevoke) WithRevocationMessage(msg string) ExecRevoke {
 	if msg != "" {
-		ex.req.RevocationReason.RevocationMessage = &msg
+		ex.req.RevocationReason.RevocationMessage = msg
 	}
 	return ex
 }

--- a/kmipclient/sign_verify.go
+++ b/kmipclient/sign_verify.go
@@ -32,7 +32,7 @@ func (c *Client) Sign(id string) ExecSignWantsData {
 	return ExecSignWantsData{
 		client: c,
 		req: &payloads.SignRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }
@@ -43,7 +43,7 @@ func (ex ExecSignWantsData) WithCryptographicParameters(params kmip.Cryptographi
 }
 
 func (ex ExecSignWantsData) Data(data []byte) ExecSign {
-	ex.req.Data = &data
+	ex.req.Data = data
 	return ExecSign{
 		Executor[*payloads.SignRequestPayload, *payloads.SignResponsePayload]{
 			client: ex.client,
@@ -53,7 +53,7 @@ func (ex ExecSignWantsData) Data(data []byte) ExecSign {
 }
 
 func (ex ExecSignWantsData) DigestedData(data []byte) ExecSign {
-	ex.req.DigestedData = &data
+	ex.req.DigestedData = data
 	return ExecSign{
 		Executor[*payloads.SignRequestPayload, *payloads.SignResponsePayload]{
 			client: ex.client,
@@ -66,7 +66,7 @@ func (c *Client) SignatureVerify(id string) ExecSignatureVerifyWantsData {
 	return ExecSignatureVerifyWantsData{
 		client: c,
 		req: &payloads.SignatureVerifyRequestPayload{
-			UniqueIdentifier: &id,
+			UniqueIdentifier: id,
 		},
 	}
 }
@@ -77,17 +77,17 @@ func (ex ExecSignatureVerifyWantsData) WithCryptographicParameters(params kmip.C
 }
 
 func (ex ExecSignatureVerifyWantsData) Data(data []byte) ExecSignatureVerifyWantsSignature {
-	ex.req.Data = &data
+	ex.req.Data = data
 	return ExecSignatureVerifyWantsSignature(ex)
 }
 
 func (ex ExecSignatureVerifyWantsData) DigestedData(data []byte) ExecSignatureVerifyWantsSignature {
-	ex.req.DigestedData = &data
+	ex.req.DigestedData = data
 	return ExecSignatureVerifyWantsSignature(ex)
 }
 
 func (ex ExecSignatureVerifyWantsData) Signature(sig []byte) ExecSignatureVerify {
-	ex.req.SignatureData = &sig
+	ex.req.SignatureData = sig
 	return ExecSignatureVerify{
 		Executor[*payloads.SignatureVerifyRequestPayload, *payloads.SignatureVerifyResponsePayload]{
 			client: ex.client,
@@ -97,7 +97,7 @@ func (ex ExecSignatureVerifyWantsData) Signature(sig []byte) ExecSignatureVerify
 }
 
 func (ex ExecSignatureVerifyWantsSignature) Signature(sig []byte) ExecSignatureVerify {
-	ex.req.SignatureData = &sig
+	ex.req.SignatureData = sig
 	return ExecSignatureVerify{
 		Executor[*payloads.SignatureVerifyRequestPayload, *payloads.SignatureVerifyResponsePayload]{
 			client: ex.client,

--- a/kmipserver/http_test.go
+++ b/kmipserver/http_test.go
@@ -22,7 +22,7 @@ func TestHttpHandler_TTLV(t *testing.T) {
 	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(func(ctx context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
 		require.NotEmpty(t, kmipserver.RemoteAddr(ctx))
 		// require.NotEmpty(t, kmipserver.PeerCertificates(ctx))
-		return &payloads.ActivateResponsePayload{UniqueIdentifier: *req.UniqueIdentifier}, nil
+		return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
 	}))
 
 	hdl := kmipserver.NewHTTPHandler(mux)
@@ -40,7 +40,7 @@ func TestHttpHandler_TTLV(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			uid := "foobar"
 			req := kmip.NewRequestMessage(kmip.V1_4, &payloads.ActivateRequestPayload{
-				UniqueIdentifier: &uid,
+				UniqueIdentifier: uid,
 			})
 			body := tc.marshal(req)
 			httpReq := httptest.NewRequest(http.MethodPost, "/kmip", bytes.NewReader(body))

--- a/kmipserver/router.go
+++ b/kmipserver/router.go
@@ -107,12 +107,12 @@ func (exec *BatchExecutor) handleRequest(ctx context.Context, req *kmip.RequestM
 	}
 
 	errorContinuationOption := kmip.Continue
-	if co := req.Header.BatchErrorContinuationOption; co != nil {
-		if *co == kmip.Undo {
+	if co := req.Header.BatchErrorContinuationOption; co > 0 {
+		if co == kmip.Undo {
 			// Reject request if set to Undo as we don't support transactions
 			return nil, Errorf(kmip.ReasonFeatureNotSupported, `"Undo" BatchErrorContinuationOption is not supported`)
 		}
-		errorContinuationOption = *co
+		errorContinuationOption = co
 	}
 
 	if int(req.Header.BatchCount) != len(req.BatchItem) {

--- a/kmipserver/server_test.go
+++ b/kmipserver/server_test.go
@@ -27,7 +27,7 @@ func TestServerRequest(t *testing.T) {
 	client := kmiptest.NewClientAndServer(t, mux)
 
 	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(func(ctx context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
-		return &payloads.ActivateResponsePayload{UniqueIdentifier: *req.UniqueIdentifier}, nil
+		return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
 	}))
 
 	resp, err := client.Activate("foobar").Exec()

--- a/objects.go
+++ b/objects.go
@@ -218,8 +218,8 @@ func (key *PublicKey) ECDSA() (*ecdsa.PublicKey, error) {
 			Curve: curve,
 		}
 		compressionType := ECPublicKeyTypeUncompressed
-		if key.KeyBlock.KeyCompressionType != nil {
-			compressionType = *key.KeyBlock.KeyCompressionType
+		if key.KeyBlock.KeyCompressionType > 0 {
+			compressionType = key.KeyBlock.KeyCompressionType
 		}
 
 		switch compressionType {
@@ -447,10 +447,10 @@ func (key *PrivateKey) Pkcs8Pem() (string, error) {
 
 type KeyBlock struct {
 	KeyFormatType          KeyFormatType
-	KeyCompressionType     *KeyCompressionType
+	KeyCompressionType     KeyCompressionType `ttlv:",omitempty"`
 	KeyValue               *KeyValue
-	CryptographicAlgorithm *CryptographicAlgorithm
-	CryptographicLength    *int32
+	CryptographicAlgorithm CryptographicAlgorithm `ttlv:",omitempty"`
+	CryptographicLength    int32                  `ttlv:",omitempty"`
 	KeyWrappingData        *KeyWrappingData
 }
 
@@ -459,7 +459,7 @@ func (kb *KeyBlock) TagDecodeTTLV(d *ttlv.Decoder, tag int) error {
 		if err := d.Any(&kb.KeyFormatType); err != nil {
 			return err
 		}
-		if err := d.Any(&kb.KeyCompressionType); err != nil {
+		if err := d.Opt(TagKeyCompressionType, &kb.KeyCompressionType); err != nil {
 			return err
 		}
 		if d.Tag() == TagKeyValue {
@@ -469,10 +469,10 @@ func (kb *KeyBlock) TagDecodeTTLV(d *ttlv.Decoder, tag int) error {
 				return err
 			}
 		}
-		if err := d.Any(&kb.CryptographicAlgorithm); err != nil {
+		if err := d.Opt(TagCryptographicAlgorithm, &kb.CryptographicAlgorithm); err != nil {
 			return err
 		}
-		if err := d.TagAny(TagCryptographicLength, &kb.CryptographicLength); err != nil {
+		if err := d.Opt(TagCryptographicLength, &kb.CryptographicLength); err != nil {
 			return err
 		}
 		if err := d.Any(&kb.KeyWrappingData); err != nil {
@@ -591,9 +591,9 @@ type KeyWrappingData struct {
 	WrappingMethod             WrappingMethod
 	EncryptionKeyInformation   *EncryptionKeyInformation
 	MACSignatureKeyInformation *MACSignatureKeyInformation
-	MACSignature               *[]byte
-	IVCounterNonce             *[]byte
-	EncodingOption             *EncodingOption `ttlv:",version=v1.1.."`
+	MACSignature               []byte         `ttlv:",omitempty"`
+	IVCounterNonce             []byte         `ttlv:",omitempty"`
+	EncodingOption             EncodingOption `ttlv:",omitempty,version=v1.1.."`
 }
 
 type EncryptionKeyInformation struct {

--- a/objects_test.go
+++ b/objects_test.go
@@ -236,7 +236,7 @@ func TestPublicKey_ECDSA(t *testing.T) {
 		comp := ECPublicKeyTypeUncompressed
 		pkey := PublicKey{KeyBlock: KeyBlock{
 			KeyFormatType:      KeyFormatTransparentECDSAPublicKey,
-			KeyCompressionType: &comp,
+			KeyCompressionType: comp,
 			KeyValue: &KeyValue{Plain: &PlainKeyValue{KeyMaterial: KeyMaterial{TransparentECDSAPublicKey: &TransparentECDSAPublicKey{
 				RecommendedCurve: P_256,
 				//nolint:staticcheck // We need this function compute ECDSA public key
@@ -255,7 +255,7 @@ func TestPublicKey_ECDSA(t *testing.T) {
 		comp := ECPublicKeyTypeX9_62CompressedPrime
 		pkey := PublicKey{KeyBlock: KeyBlock{
 			KeyFormatType:      KeyFormatTransparentECDSAPublicKey,
-			KeyCompressionType: &comp,
+			KeyCompressionType: comp,
 			KeyValue: &KeyValue{Plain: &PlainKeyValue{KeyMaterial: KeyMaterial{TransparentECDSAPublicKey: &TransparentECDSAPublicKey{
 				RecommendedCurve: P_256,
 				QString:          elliptic.MarshalCompressed(elliptic.P256(), ecKey.X, ecKey.Y),

--- a/payloads/activate.go
+++ b/payloads/activate.go
@@ -16,7 +16,7 @@ var _ kmip.OperationPayload = (*ActivateRequestPayload)(nil)
 type ActivateRequestPayload struct {
 	// Determines the object being activated.
 	// If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 }
 
 // Operation implements kmip.OperationPayload.

--- a/payloads/add_attribute.go
+++ b/payloads/add_attribute.go
@@ -16,7 +16,7 @@ func init() {
 type AddAttributeRequestPayload struct {
 	// The Unique Identifier of the object.
 	// If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// Specifies the attribute to be added as an attribute for the object.
 	Attribute kmip.Attribute
 }

--- a/payloads/archive_recover.go
+++ b/payloads/archive_recover.go
@@ -16,7 +16,7 @@ func init() {
 type ArchiveRequestPayload struct {
 	// Determines the object being archived.
 	// If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 }
 
 func (pl *ArchiveRequestPayload) Operation() kmip.Operation {
@@ -38,7 +38,7 @@ func (pl *ArchiveResponsePayload) Operation() kmip.Operation {
 // Once the response is received, the object is now on-line, and MAY be obtained (e.g., via a Get operation).
 // Special authentication and authorization SHOULD be enforced to perform this request.
 type RecoverRequestPayload struct {
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 }
 
 func (pl *RecoverRequestPayload) Operation() kmip.Operation {

--- a/payloads/delete_attribute.go
+++ b/payloads/delete_attribute.go
@@ -15,7 +15,7 @@ func init() {
 // requests MAY be included in a single batched request to delete multiple attributes.
 type DeleteAttributeRequestPayload struct {
 	// Determines the object whose attributes are being deleted. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// Specifies the name of the attribute associated with the object to be deleted.
 	AttributeName kmip.AttributeName
 	// Specifies the Index of the Attribute.

--- a/payloads/destroy.go
+++ b/payloads/destroy.go
@@ -17,7 +17,7 @@ var _ kmip.OperationPayload = (*DestroyRequestPayload)(nil)
 // then the object itself, including all meta-data, SHALL be destroyed. Cryptographic Objects MAY only be destroyed if they are in either Pre-Active or Deactivated state.
 type DestroyRequestPayload struct {
 	// Determines the object being destroyed. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 }
 
 // Operation implements kmip.OperationPayload.

--- a/payloads/encrypt_decrypt.go
+++ b/payloads/encrypt_decrypt.go
@@ -23,7 +23,7 @@ type EncryptRequestPayload struct {
 	// The Unique Identifier of the Managed Cryptographic Object that is the key to
 	// use for the encryption operation. If omitted, then the ID Placeholder value
 	// SHALL be used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// The Cryptographic Parameters (Block Cipher Mode, Padding Method, RandomIV) corresponding to the
 	// particular encryption method requested. If omitted then the Cryptographic Parameters associated
 	// with the Managed Cryptographic Object with the lowest Attribute Index SHALL be used. If there are no Cryptographic
@@ -33,7 +33,7 @@ type EncryptRequestPayload struct {
 	// The data to be encrypted (as a Byte String).
 	Data []byte `ttlv:",omitempty"`
 	// The initialization vector, counter or nonce to be used (where appropriate).
-	IVCounterNonce *[]byte
+	IVCounterNonce []byte `ttlv:",omitempty"`
 	// Specifies the existing stream or by-parts cryptographic operation (as returned from a previous call to this operation).
 	//
 	// The Correlation Value is used in requests and responses in cryptographic operations that support multi-
@@ -41,7 +41,7 @@ type EncryptRequestPayload struct {
 	// operation that is being performed across multiple requests. Note: the server decides which operations are
 	// supported for multi-part usage. A server-generated correlation value SHALL be specified in any
 	// subsequent cryptographic operations that pertain to the original operation.
-	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	CorrelationValue []byte `ttlv:",omitempty,version=v1.3.."`
 	// Initial operation as Boolean.
 	//
 	// The Init Indicator is used in requests in cryptographic operations that support multi-part (streaming)
@@ -59,7 +59,7 @@ type EncryptRequestPayload struct {
 	//
 	// The Authenticated Encryption Additional Data object is used in authenticated encryption and decryption
 	// operations that require the optional additional data to be provided by the client.
-	AuthenticatedEncryptionAdditionalData *[]byte `ttlv:",version=v1.4.."`
+	AuthenticatedEncryptionAdditionalData []byte `ttlv:",omitempty,version=v1.4.."`
 }
 
 func (pl *EncryptRequestPayload) Operation() kmip.Operation {
@@ -74,7 +74,7 @@ type EncryptResponsePayload struct {
 	Data []byte `ttlv:",omitempty"`
 	// The value used if the Cryptographic Parameters specified Random IV and the IV/Counter/Nonce value was not provided in the request
 	// and the algorithm requires the provision of an IV/Counter/Nonce.
-	IVCounterNonce *[]byte
+	IVCounterNonce []byte `ttlv:",omitempty"`
 	// Specifies the stream or by-parts value to be provided in subsequent calls to this operation for performing cryptographic operations.
 	//
 	// The Correlation Value is used in requests and responses in cryptographic operations that support multi-
@@ -82,14 +82,14 @@ type EncryptResponsePayload struct {
 	// operation that is being performed across multiple requests. Note: the server decides which operations are
 	// supported for multi-part usage. A server-generated correlation value SHALL be specified in any
 	// subsequent cryptographic operations that pertain to the original operation.
-	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	CorrelationValue []byte `ttlv:",omitempty,version=v1.3.."`
 	// Specifies the tag that will be needed to authenticate the decrypted data.
 	// Only returned on completion of the encryption of the last of the plaintext by an authenticated encryption cipher.
 	//
 	// The Authenticated Encryption Tag object is used to validate the integrity of the data encrypted and
 	// decrypted in Authenticated Encryption modes. It is an output from the encryption process and an input to
 	// the decryption process. See [SP800-38D].
-	AuthenticatedEncryptionTag *[]byte `ttlv:",version=v1.4.."`
+	AuthenticatedEncryptionTag []byte `ttlv:",omitempty,version=v1.4.."`
 }
 
 func (pl *EncryptResponsePayload) Operation() kmip.Operation {
@@ -104,7 +104,7 @@ func (pl *EncryptResponsePayload) Operation() kmip.Operation {
 type DecryptRequestPayload struct {
 	// The Unique Identifier of the Managed Cryptographic Object that is the key to use for the decryption operation.
 	// If omitted, then the ID Placeholder value SHALL be used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// The Cryptographic Parameters (Block Cipher Mode, Padding Method) corresponding to the particular decryption method requested.
 	// If omitted then the Cryptographic Parameters associated with the Managed Cryptographic Object with the lowest Attribute Index SHALL be used.
 	//
@@ -114,7 +114,7 @@ type DecryptRequestPayload struct {
 	// The data to be decrypted (as a Byte String).
 	Data []byte `ttlv:",omitempty"`
 	// The initialization vector, counter or nonce to be used (where appropriate).
-	IVCounterNonce *[]byte
+	IVCounterNonce []byte `ttlv:",omitempty"`
 	// Specifies the existing stream or by-parts cryptographic operation (as returned from a previous call to this operation).
 	//
 	// The Correlation Value is used in requests and responses in cryptographic operations that support multi-
@@ -122,7 +122,7 @@ type DecryptRequestPayload struct {
 	// operation that is being performed across multiple requests. Note: the server decides which operations are
 	// supported for multi-part usage. A server-generated correlation value SHALL be specified in any
 	// subsequent cryptographic operations that pertain to the original operation.
-	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	CorrelationValue []byte `ttlv:",omitempty,version=v1.3.."`
 	// Initial operation as Boolean.
 	//
 	// The Init Indicator is used in requests in cryptographic operations that support multi-part (streaming)
@@ -140,14 +140,14 @@ type DecryptRequestPayload struct {
 	//
 	// The Authenticated Encryption Additional Data object is used in authenticated encryption and decryption
 	// operations that require the optional additional data to be provided by the client.
-	AuthenticatedEncryptionAdditionalData *[]byte `ttlv:",version=v1.4.."`
+	AuthenticatedEncryptionAdditionalData []byte `ttlv:",omitempty,version=v1.4.."`
 	// Specifies the tag that will be needed to authenticate the decrypted data.
 	// If supplied in multi-part decryption, this data MUST be supplied on the initial Decrypt request.
 	//
 	// The Authenticated Encryption Tag object is used to validate the integrity of the data encrypted and
 	// decrypted in Authenticated Encryption modes. It is an output from the encryption process and an input to
 	// the decryption process. See [SP800-38D].
-	AuthenticatedEncryptionTag *[]byte `ttlv:",version=v1.4.."`
+	AuthenticatedEncryptionTag []byte `ttlv:",omitempty,version=v1.4.."`
 }
 
 func (pl *DecryptRequestPayload) Operation() kmip.Operation {
@@ -167,7 +167,7 @@ type DecryptResponsePayload struct {
 	// operation that is being performed across multiple requests. Note: the server decides which operations are
 	// supported for multi-part usage. A server-generated correlation value SHALL be specified in any
 	// subsequent cryptographic operations that pertain to the original operation.
-	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	CorrelationValue []byte `ttlv:",omitempty,version=v1.3.."`
 }
 
 func (pl *DecryptResponsePayload) Operation() kmip.Operation {

--- a/payloads/get.go
+++ b/payloads/get.go
@@ -31,13 +31,13 @@ func init() {
 // and then using each certificate’s Certificate Link to build the certificate chain.  It is an error if there is more than one valid certificate chain.
 type GetRequestPayload struct {
 	// Determines the object being requested. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// Determines the key format type to be returned.
-	KeyFormatType *kmip.KeyFormatType
+	KeyFormatType kmip.KeyFormatType `ttlv:",omitempty"`
 	// Determines the Key Wrap Type of the returned key value.
-	KeyWrapType *kmip.KeyFormatType `ttlv:",version=v1.4.."`
+	KeyWrapType kmip.KeyFormatType `ttlv:",omitempty,version=v1.4.."`
 	// Determines the compression method for elliptic curve public keys.
-	KeyCompressionType *kmip.KeyCompressionType
+	KeyCompressionType kmip.KeyCompressionType `ttlv:",omitempty"`
 	// Specifies keys and other information for wrapping the returned object. This field SHALL NOT be specified if the requested object is a Template.
 	KeyWrappingSpecification *kmip.KeyWrappingSpecification
 }

--- a/payloads/get_attribute_list.go
+++ b/payloads/get_attribute_list.go
@@ -9,7 +9,7 @@ func init() {
 // This operation requests a list of the attribute names associated with a Managed Object. The object is specified by its Unique Identifier.
 type GetAttributeListRequestPayload struct {
 	// Determines the object whose attribute names are being requested. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 }
 
 func (pl *GetAttributeListRequestPayload) Operation() kmip.Operation {

--- a/payloads/get_attributes.go
+++ b/payloads/get_attributes.go
@@ -18,7 +18,7 @@ var _ kmip.OperationPayload = (*GetAttributesRequestPayload)(nil)
 // The same attribute name SHALL NOT be present more than once in a request.
 type GetAttributesRequestPayload struct {
 	// Determines the object whose attributes are being requested. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// Specifies the name of an attribute associated with the object.
 	AttributeName []kmip.AttributeName
 }

--- a/payloads/get_usage.go
+++ b/payloads/get_usage.go
@@ -22,7 +22,7 @@ func init() {
 // until a new allocation is obtained.
 type GetUsageAllocationRequestPayload struct {
 	// Determines the object whose usage allocation is being requested. If omitted, then the ID Placeholder is substituted by the server.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// The number of Usage Limits Units to be protected.
 	UsageLimitsCount int64
 }

--- a/payloads/locate.go
+++ b/payloads/locate.go
@@ -61,14 +61,14 @@ func init() {
 // objects are to be searched. Note that the server MAY store attributes of archived objects in order to expedite Locate operations that search through archived objects.
 type LocateRequestPayload struct {
 	// An Integer object that indicates the maximum number of object identifiers the server MAY return.
-	MaximumItems *int32
+	MaximumItems int32 `ttlv:",omitempty"`
 	// An Integer object that indicates the number of object identifiers to skip that satisfy the identification criteria specified in the request.
-	OffsetItems *int32 `ttlv:",version=1.3.."`
+	OffsetItems int32 `ttlv:",omitempty,version=1.3.."`
 	// An Integer object (used as a bit mask) that indicates whether only on-line objects, only archived objects,
 	// or both on-line and archived objects are to be searched. If omitted, then on-line only is assumed.
-	StorageStatusMask *kmip.StorageStatusMask
+	StorageStatusMask kmip.StorageStatusMask `ttlv:",omitempty"`
 	// An Enumeration object that indicates the object group member type.
-	ObjectGroupMember *kmip.ObjectGroupMember `ttlv:",version=1.1.."`
+	ObjectGroupMember kmip.ObjectGroupMember `ttlv:",omitempty,version=1.1.."`
 	// Specifies an attribute and its value(s) that are REQUIRED to match those in a candidate object (according to the matching rules defined above).
 	Attribute []kmip.Attribute
 }

--- a/payloads/modify_attribute.go
+++ b/payloads/modify_attribute.go
@@ -18,7 +18,7 @@ func init() {
 // Multiple Modify Attribute requests MAY be included in a single batched request to modify multiple attributes.
 type ModifyAttributeRequestPayload struct {
 	// The Unique Identifier of the object. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// Specifies the attribute associated with the object to be modified.
 	Attribute kmip.Attribute
 }

--- a/payloads/obtain_lease.go
+++ b/payloads/obtain_lease.go
@@ -21,7 +21,7 @@ func init() {
 // by comparing this time to the time when the attributes were previously obtained.
 type ObtainLeaseRequestPayload struct {
 	// Determines the object for which the lease is being obtained. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 }
 
 func (pl *ObtainLeaseRequestPayload) Operation() kmip.Operation {

--- a/payloads/query.go
+++ b/payloads/query.go
@@ -79,7 +79,7 @@ type QueryResponsePayload struct {
 	// Specifies a Managed Object Type that is supported by the server.
 	ObjectType []kmip.ObjectType
 	// SHALL be returned if Query Server Information is requested. The Vendor Identification SHALL be a text string that uniquely identifies the vendor.
-	VendorIdentification *string
+	VendorIdentification string `ttlv:",omitempty"`
 	// Contains vendor-specific information possibly be of interest to the client.
 	ServerInformation *ttlv.Value
 	// Specifies an Application Namespace supported by the server.

--- a/payloads/rekey.go
+++ b/payloads/rekey.go
@@ -46,7 +46,7 @@ func init() {
 //   - Random Number Generator: Set to the random number generator used for creating the new managed object. Not copied from the original object.
 type RekeyRequestPayload struct {
 	// Determines the existing Symmetric Key being re-keyed. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// An Interval object indicating the difference between the Initialization Date and the Activation Date of the replacement key to be created.
 	Offset *time.Duration
 	// Specifies desired object attributes using templates and/or individual attributes.

--- a/payloads/revoke.go
+++ b/payloads/revoke.go
@@ -22,7 +22,7 @@ var _ kmip.OperationPayload = (*RevokeRequestPayload)(nil)
 // the object is placed into the “deactivated” state, and the Deactivation Date is set to the current date and time.
 type RevokeRequestPayload struct {
 	// Determines the object being revoked. If omitted, then the ID Placeholder value is used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// Specifies the reason for revocation.
 	RevocationReason kmip.RevocationReason
 	// SHOULD be specified if the Revocation Reason is 'key compromise' or ‘CA compromise’ and SHALL NOT be specified for other Revocation Reason enumerations.

--- a/payloads/sign_verify.go
+++ b/payloads/sign_verify.go
@@ -21,7 +21,7 @@ func init() {
 type SignRequestPayload struct {
 	// The Unique Identifier of the Managed Cryptographic Object that is the key to use for the signature operation. If
 	// omitted, then the ID Placeholder value SHALL be used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// The Cryptographic Parameters (Digital Signature Algorithm or Cryptographic Algorithm and Hashing Algorithm) corresponding
 	// to the particular signature generation method requested. If omitted then the Cryptographic Parameters associated
 	// with the Managed Cryptographic Object with the lowest Attribute Index SHALL be used.
@@ -29,11 +29,11 @@ type SignRequestPayload struct {
 	// the operation SHALL return with a Result Status of Operation Failed.
 	CryptographicParameters *kmip.CryptographicParameters
 	// The data to be signed. Mandatory for kmip 1.2 or single-part operation, unless Digested Data is supplied. Optional for multi-part.
-	Data *[]byte
+	Data []byte `ttlv:",omitempty"`
 	// The digested data to be signed.
-	DigestedData *[]byte `ttlv:",version=v1.4.."`
+	DigestedData []byte `ttlv:",omitempty,version=v1.4.."`
 	// Specifies the existing stream or by parts cryptographic operation (as returned from a previous call to this operation).
-	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	CorrelationValue []byte `ttlv:",omitempty,version=v1.3.."`
 	// Initial operation.
 	InitIndicator *bool `ttlv:",version=v1.3.."`
 	// Final operation.
@@ -55,9 +55,9 @@ type SignResponsePayload struct {
 	// The Unique Identifier of the Managed Cryptographic Object that is the key used for the signature operation.
 	UniqueIdentifier string
 	// The signed data. Mandatory for kmip 1.2 or single-part operation, not for multi-part.
-	SignatureData *[]byte
+	SignatureData []byte `ttlv:",omitempty"`
 	// Specifies the stream or by-parts value to be provided in subsequent calls to this operation for performing cryptographic operations.
-	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	CorrelationValue []byte `ttlv:",omitempty,version=v1.3.."`
 }
 
 func (pl *SignResponsePayload) Operation() kmip.Operation {
@@ -76,7 +76,7 @@ func (pl *SignResponsePayload) Operation() kmip.Operation {
 type SignatureVerifyRequestPayload struct {
 	// The Unique Identifier of the Managed Cryptographic Object that is the key to use for the signature verify operation.
 	// If omitted, then the ID Placeholder value SHALL be used by the server as the Unique Identifier.
-	UniqueIdentifier *string
+	UniqueIdentifier string `ttlv:",omitempty"`
 	// The Cryptographic Parameters (Digital Signature Algorithm or Cryptographic Algorithm and Hashing Algorithm)
 	// corresponding to the particular signature verification method requested. If omitted then the Cryptographic
 	// Parameters associated with the Managed Cryptographic Object with the lowest Attribute Index SHALL be used.
@@ -85,13 +85,13 @@ type SignatureVerifyRequestPayload struct {
 	// parameters then the operation SHALL return with a Result Status of Operation Failed.
 	CryptographicParameters *kmip.CryptographicParameters
 	// The data that was signed.
-	Data *[]byte
+	Data []byte `ttlv:",omitempty"`
 	// The digested data to be verified.
-	DigestedData *[]byte `ttlv:",version=v1.4.."`
+	DigestedData []byte `ttlv:",omitempty,version=v1.4.."`
 	// The signature to be verified. Mandatory for kmip 1.2 or for single-part operation. Not for multi-part.
-	SignatureData *[]byte
+	SignatureData []byte `ttlv:",omitempty"`
 	// Specifies the existing stream or by-parts cryptographic operation (as returned from a previous call to this operation).
-	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	CorrelationValue []byte `ttlv:",omitempty,version=v1.3.."`
 	// Initial operation.
 	InitIndicator *bool `ttlv:",version=v1.3.."`
 	// Final operation.
@@ -116,9 +116,9 @@ type SignatureVerifyResponsePayload struct {
 	// An Enumeration object indicating whether the signature is valid, invalid, or unknown.
 	ValidityIndicator kmip.ValidityIndicator
 	// The OPTIONAL recovered data (as a Byte String) for those signature algorithms where data recovery from the signature is supported.
-	Data *[]byte
+	Data []byte `ttlv:",omitempty"`
 	// Specifies the stream or by-parts value to be provided in subsequent calls to this operation for performing cryptographic operations.
-	CorrelationValue *[]byte `ttlv:",version=v1.3.."`
+	CorrelationValue []byte `ttlv:",omitempty,version=v1.3.."`
 }
 
 func (pl *SignatureVerifyResponsePayload) Operation() kmip.Operation {

--- a/requests.go
+++ b/requests.go
@@ -38,15 +38,15 @@ func NewRequestMessage(version ProtocolVersion, payloads ...OperationPayload) Re
 
 type RequestHeader struct {
 	ProtocolVersion     ProtocolVersion `ttlv:",set-version"`
-	MaximumResponseSize *int32
+	MaximumResponseSize int32           `ttlv:",omitempty"`
 
-	ClientCorrelationValue       *string `ttlv:",version=v1.4.."`
-	ServerCorrelationValue       *string `ttlv:",version=v1.4.."`
+	ClientCorrelationValue       string `ttlv:",omitempty,version=v1.4.."`
+	ServerCorrelationValue       string `ttlv:",omitempty,version=v1.4.."`
 	AsynchronousIndicator        *bool
 	AttestationCapableIndicator  *bool             `ttlv:",version=v1.2.."`
 	AttestationType              []AttestationType `ttlv:",version=v1.2.."`
 	Authentication               *Authentication
-	BatchErrorContinuationOption *BatchErrorContinuationOption
+	BatchErrorContinuationOption BatchErrorContinuationOption `ttlv:",omitempty"`
 	BatchOrderOption             *bool
 	TimeStamp                    *time.Time
 	BatchCount                   int32
@@ -54,7 +54,7 @@ type RequestHeader struct {
 
 type RequestBatchItem struct {
 	Operation         Operation
-	UniqueBatchItemID []byte
+	UniqueBatchItemID []byte `ttlv:",omitempty"`
 	RequestPayload    OperationPayload
 	MessageExtension  *MessageExtension
 }

--- a/responses.go
+++ b/responses.go
@@ -17,18 +17,18 @@ type ResponseHeader struct {
 	TimeStamp              time.Time
 	Nonce                  *Nonce            `ttlv:",version=v1.2.."`
 	AttestationType        []AttestationType `ttlv:",version=v1.2.."`
-	ClientCorrelationValue *string           `ttlv:",version=v1.4.."`
-	ServerCorrelationValue *string           `ttlv:",version=v1.4.."`
+	ClientCorrelationValue string            `ttlv:",omitempty,version=v1.4.."`
+	ServerCorrelationValue string            `ttlv:",omitempty,version=v1.4.."`
 	BatchCount             int32
 }
 
 type ResponseBatchItem struct {
-	Operation                    Operation
-	UniqueBatchItemID            []byte
+	Operation                    Operation `ttlv:",omitempty"`
+	UniqueBatchItemID            []byte    `ttlv:",omitempty"`
 	ResultStatus                 ResultStatus
 	ResultReason                 ResultReason `ttlv:",omitempty"`
 	ResultMessage                string       `ttlv:",omitempty"`
-	AsynchronousCorrelationValue []byte
+	AsynchronousCorrelationValue []byte       `ttlv:",omitempty"`
 	ResponsePayload              OperationPayload
 	MessageExtension             *MessageExtension
 }


### PR DESCRIPTION
This makes the user code cleaner and simpler to use, avoids pointer boilerplates and reduces allocations. However, it makes it a bit leass explicit about what is optional vs what's not