### PR TITLE
fix: truncate requests header timestamp instead of rounding

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -13,7 +13,7 @@ type RequestMessage struct {
 }
 
 func NewRequestMessage(version ProtocolVersion, payloads ...OperationPayload) RequestMessage {
-	timestamp := time.Now().Round(time.Second)
+	timestamp := time.Now().Truncate(time.Second)
 	msg := RequestMessage{
 		Header: RequestHeader{
 			ProtocolVersion: version,


### PR DESCRIPTION
This avoids having 50% of timestamps being in the future, which is rejected by some servers like PyKMIP