### PR TITLE
feat(client): add helpers to build and run batch requests

### DIFF
--- a/examples/batches.go
+++ b/examples/batches.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/ovh/kmip-go"
+	"github.com/ovh/kmip-go/kmipclient"
+	"github.com/ovh/kmip-go/payloads"
+)
+
+func test_batch_helper(client *kmipclient.Client) {
+	resp := client.Create().
+		AES(256, kmip.CryptographicUsageEncrypt|kmip.CryptographicUsageDecrypt).
+		Then(func(client *kmipclient.Client) kmipclient.PayloadBuilder {
+			return client.Activate("")
+		}).
+		Then(func(client *kmipclient.Client) kmipclient.PayloadBuilder {
+			return client.Revoke("").
+				WithRevocationReasonCode(kmip.RevocationReasonCodeCessationOfOperation)
+		}).
+		Then(func(client *kmipclient.Client) kmipclient.PayloadBuilder {
+			return client.Destroy("")
+		}).MustExec().
+		MustUnwrap()
+
+	fmt.Println(resp[3].(*payloads.DestroyResponsePayload).UniqueIdentifier)
+}
+
+func test_encrypt_by_name(client *kmipclient.Client) {
+	iv := make([]byte, kmip.AES_GCM.IVLength)
+	_, _ = rand.Read(iv)
+
+	res := client.Locate().
+		WithName("my-encryption-AES-key").
+		Then(func(client *kmipclient.Client) kmipclient.PayloadBuilder {
+			return client.Encrypt("").
+				WithCryptographicParameters(kmip.AES_GCM).
+				WithIvCounterNonce(iv).
+				Data([]byte("My Secret Data"))
+		}).
+		MustExec(kmipclient.OnBatchErr(kmip.BatchErrorContinuationOptionStop)).
+		MustUnwrap()
+
+	pl := res[1].(*payloads.EncryptResponsePayload)
+	cipher := append([]byte{}, pl.IVCounterNonce...)
+	cipher = append(cipher, pl.Data...)
+	cipher = append(cipher, pl.AuthenticatedEncryptionTag...)
+
+	fmt.Println("Key ID:", pl.UniqueIdentifier)
+	fmt.Println("Cipher:", base64.StdEncoding.EncodeToString(cipher))
+
+	client.Decrypt(pl.UniqueIdentifier).
+		WithCryptographicParameters(kmip.AES_GCM).
+		WithAuthTag(pl.AuthenticatedEncryptionTag).
+		WithIvCounterNonce(pl.IVCounterNonce).
+		Data(pl.Data).
+		MustExec()
+}

--- a/examples/main.go
+++ b/examples/main.go
@@ -32,14 +32,18 @@ const (
 
 var RESOURCE = "cb0ea267-d912-4bd4-9be2-2093e1ed02a4"
 
+//nolint:funlen // list all examples
 func main() {
 	client := newClient()
 	defer client.Close()
 
-	unsupported_operation(client)
+	test_batch_helper(client)
+	test_encrypt_by_name(client)
 
 	activateAll(client)
 	cleanupDomain(client)
+
+	unsupported_operation(client)
 
 	time_consuming_batch(client)
 


### PR DESCRIPTION
Introduce helper functions to facilitate building and executing batch requests in the client. These changes enhance the client's capabilities for handling multiple operations in a single request.

# Example
```go
resp := client.Create().
        AES(256, kmip.CryptographicUsageEncrypt|kmip.CryptographicUsageDecrypt).
        Then(func(client *kmipclient.Client) kmipclient.PayloadBuilder {
	        return client.Activate("")
        }).
        Then(func(client *kmipclient.Client) kmipclient.PayloadBuilder {
	        return client.Revoke("").
		        WithRevocationReasonCode(kmip.RevocationReasonCodeCessationOfOperation)
        }).
        Then(func(client *kmipclient.Client) kmipclient.PayloadBuilder {
	        return client.Destroy("")
        }).MustExec().
        MustUnwrap()

fmt.Println(resp[3].(*payloads.DestroyResponsePayload).UniqueIdentifier)
```

This will also allow, for example, to perform requests on object located by their names, withut having to run a query first to obtain the object's ID, thus reducing the amount of request and roundtrip time.
```go
client.Locate().
    WithName("my-encryption-AES-key").
    Then(func(client *kmipclient.Client) kmipclient.PayloadBuilder {
	    return client.Encrypt("").
		    WithCryptographicParameters(kmip.AES_GCM).
		    WithIvCounterNonce(iv).
		    Data([]byte("My Secret Data"))
    }).
    MustExec(kmipclient.OnBatchErr(kmip.BatchErrorContinuationOptionStop)).
    MustUnwrap()
```
		