### PR TITLE
fix(kmip)!: remove PKCS suffixes in DigitalSignatureAlgorithm enum

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -415,22 +415,22 @@ func init() {
 		EncodingOptionTTLVEncoding: "TTLVEncoding",
 	})
 	ttlv.RegisterEnum(TagDigitalSignatureAlgorithm, map[DigitalSignatureAlgorithm]string{
-		DigitalSignatureAlgorithmMD2WithRSAEncryptionPKCS_1v1_5:     "MD2WithRSAEncryptionPKCS_1V1_5",
-		DigitalSignatureAlgorithmMD5WithRSAEncryptionPKCS_1v1_5:     "MD5WithRSAEncryptionPKCS_1V1_5",
-		DigitalSignatureAlgorithmSHA_1WithRSAEncryptionPKCS_1v1_5:   "SHA_1WithRSAEncryptionPKCS_1V1_5",
-		DigitalSignatureAlgorithmSHA_224WithRSAEncryptionPKCS_1v1_5: "SHA_224WithRSAEncryptionPKCS_1V1_5",
-		DigitalSignatureAlgorithmSHA_256WithRSAEncryptionPKCS_1v1_5: "SHA_256WithRSAEncryptionPKCS_1V1_5",
-		DigitalSignatureAlgorithmSHA_384WithRSAEncryptionPKCS_1v1_5: "SHA_384WithRSAEncryptionPKCS_1V1_5",
-		DigitalSignatureAlgorithmSHA_512WithRSAEncryptionPKCS_1v1_5: "SHA_512WithRSAEncryptionPKCS_1V1_5",
-		DigitalSignatureAlgorithmRSASSA_PSSPKCS_1v2_1:               "RSASSA_PSSPKCS_1V2_1",
-		DigitalSignatureAlgorithmDSAWithSHA_1:                       "DSAWithSHA_1",
-		DigitalSignatureAlgorithmDSAWithSHA224:                      "DSAWithSHA224",
-		DigitalSignatureAlgorithmDSAWithSHA256:                      "DSAWithSHA256",
-		DigitalSignatureAlgorithmECDSAWithSHA_1:                     "ECDSAWithSHA_1",
-		DigitalSignatureAlgorithmECDSAWithSHA224:                    "ECDSAWithSHA224",
-		DigitalSignatureAlgorithmECDSAWithSHA256:                    "ECDSAWithSHA256",
-		DigitalSignatureAlgorithmECDSAWithSHA384:                    "ECDSAWithSHA384",
-		DigitalSignatureAlgorithmECDSAWithSHA512:                    "ECDSAWithSHA512",
+		DigitalSignatureAlgorithmMD2WithRSAEncryption:     "MD2WithRSAEncryption",
+		DigitalSignatureAlgorithmMD5WithRSAEncryption:     "MD5WithRSAEncryption",
+		DigitalSignatureAlgorithmSHA_1WithRSAEncryption:   "SHA_1WithRSAEncryption",
+		DigitalSignatureAlgorithmSHA_224WithRSAEncryption: "SHA_224WithRSAEncryption",
+		DigitalSignatureAlgorithmSHA_256WithRSAEncryption: "SHA_256WithRSAEncryption",
+		DigitalSignatureAlgorithmSHA_384WithRSAEncryption: "SHA_384WithRSAEncryption",
+		DigitalSignatureAlgorithmSHA_512WithRSAEncryption: "SHA_512WithRSAEncryption",
+		DigitalSignatureAlgorithmRSASSA_PSS:               "RSASSA_PSS",
+		DigitalSignatureAlgorithmDSAWithSHA_1:             "DSAWithSHA_1",
+		DigitalSignatureAlgorithmDSAWithSHA224:            "DSAWithSHA224",
+		DigitalSignatureAlgorithmDSAWithSHA256:            "DSAWithSHA256",
+		DigitalSignatureAlgorithmECDSAWithSHA_1:           "ECDSAWithSHA_1",
+		DigitalSignatureAlgorithmECDSAWithSHA224:          "ECDSAWithSHA224",
+		DigitalSignatureAlgorithmECDSAWithSHA256:          "ECDSAWithSHA256",
+		DigitalSignatureAlgorithmECDSAWithSHA384:          "ECDSAWithSHA384",
+		DigitalSignatureAlgorithmECDSAWithSHA512:          "ECDSAWithSHA512",
 
 		// KMIP 1.4.
 		DigitalSignatureAlgorithmSHA3_256WithRSAEncryption: "SHA3_256WithRSAEncryption",
@@ -1285,22 +1285,22 @@ const (
 type DigitalSignatureAlgorithm uint32
 
 const (
-	DigitalSignatureAlgorithmMD2WithRSAEncryptionPKCS_1v1_5     DigitalSignatureAlgorithm = 0x00000001
-	DigitalSignatureAlgorithmMD5WithRSAEncryptionPKCS_1v1_5     DigitalSignatureAlgorithm = 0x00000002
-	DigitalSignatureAlgorithmSHA_1WithRSAEncryptionPKCS_1v1_5   DigitalSignatureAlgorithm = 0x00000003
-	DigitalSignatureAlgorithmSHA_224WithRSAEncryptionPKCS_1v1_5 DigitalSignatureAlgorithm = 0x00000004
-	DigitalSignatureAlgorithmSHA_256WithRSAEncryptionPKCS_1v1_5 DigitalSignatureAlgorithm = 0x00000005
-	DigitalSignatureAlgorithmSHA_384WithRSAEncryptionPKCS_1v1_5 DigitalSignatureAlgorithm = 0x00000006
-	DigitalSignatureAlgorithmSHA_512WithRSAEncryptionPKCS_1v1_5 DigitalSignatureAlgorithm = 0x00000007
-	DigitalSignatureAlgorithmRSASSA_PSSPKCS_1v2_1               DigitalSignatureAlgorithm = 0x00000008
-	DigitalSignatureAlgorithmDSAWithSHA_1                       DigitalSignatureAlgorithm = 0x00000009
-	DigitalSignatureAlgorithmDSAWithSHA224                      DigitalSignatureAlgorithm = 0x0000000A
-	DigitalSignatureAlgorithmDSAWithSHA256                      DigitalSignatureAlgorithm = 0x0000000B
-	DigitalSignatureAlgorithmECDSAWithSHA_1                     DigitalSignatureAlgorithm = 0x0000000C
-	DigitalSignatureAlgorithmECDSAWithSHA224                    DigitalSignatureAlgorithm = 0x0000000D
-	DigitalSignatureAlgorithmECDSAWithSHA256                    DigitalSignatureAlgorithm = 0x0000000E
-	DigitalSignatureAlgorithmECDSAWithSHA384                    DigitalSignatureAlgorithm = 0x0000000F
-	DigitalSignatureAlgorithmECDSAWithSHA512                    DigitalSignatureAlgorithm = 0x00000010
+	DigitalSignatureAlgorithmMD2WithRSAEncryption     DigitalSignatureAlgorithm = 0x00000001
+	DigitalSignatureAlgorithmMD5WithRSAEncryption     DigitalSignatureAlgorithm = 0x00000002
+	DigitalSignatureAlgorithmSHA_1WithRSAEncryption   DigitalSignatureAlgorithm = 0x00000003
+	DigitalSignatureAlgorithmSHA_224WithRSAEncryption DigitalSignatureAlgorithm = 0x00000004
+	DigitalSignatureAlgorithmSHA_256WithRSAEncryption DigitalSignatureAlgorithm = 0x00000005
+	DigitalSignatureAlgorithmSHA_384WithRSAEncryption DigitalSignatureAlgorithm = 0x00000006
+	DigitalSignatureAlgorithmSHA_512WithRSAEncryption DigitalSignatureAlgorithm = 0x00000007
+	DigitalSignatureAlgorithmRSASSA_PSS               DigitalSignatureAlgorithm = 0x00000008
+	DigitalSignatureAlgorithmDSAWithSHA_1             DigitalSignatureAlgorithm = 0x00000009
+	DigitalSignatureAlgorithmDSAWithSHA224            DigitalSignatureAlgorithm = 0x0000000A
+	DigitalSignatureAlgorithmDSAWithSHA256            DigitalSignatureAlgorithm = 0x0000000B
+	DigitalSignatureAlgorithmECDSAWithSHA_1           DigitalSignatureAlgorithm = 0x0000000C
+	DigitalSignatureAlgorithmECDSAWithSHA224          DigitalSignatureAlgorithm = 0x0000000D
+	DigitalSignatureAlgorithmECDSAWithSHA256          DigitalSignatureAlgorithm = 0x0000000E
+	DigitalSignatureAlgorithmECDSAWithSHA384          DigitalSignatureAlgorithm = 0x0000000F
+	DigitalSignatureAlgorithmECDSAWithSHA512          DigitalSignatureAlgorithm = 0x00000010
 
 	// KMIP 1.4.
 	DigitalSignatureAlgorithmSHA3_256WithRSAEncryption DigitalSignatureAlgorithm = 0x00000011

--- a/examples/sign_verify.go
+++ b/examples/sign_verify.go
@@ -15,7 +15,7 @@ import (
 func test_sign_verify_rsa_pkcs1_15(client *kmipclient.Client) {
 	data := []byte("foobarbaz")
 	cparams := kmip.CryptographicParameters{
-		DigitalSignatureAlgorithm: kmip.DigitalSignatureAlgorithmSHA_256WithRSAEncryptionPKCS_1v1_5,
+		DigitalSignatureAlgorithm: kmip.DigitalSignatureAlgorithmSHA_256WithRSAEncryption,
 		// CryptographicAlgorithm: kmip.CryptographicAlgorithmRSA,
 		// HashingAlgorithm:       kmip.HashingAlgorithmSHA_256,
 		// PaddingMethod:          kmip.PaddingMethodPKCS1V1_5,
@@ -41,7 +41,7 @@ func test_sign_verify_rsa_pkcs1_15(client *kmipclient.Client) {
 func test_sign_verify_rsa_pss(client *kmipclient.Client) {
 	data := []byte("foobarbaz")
 	cparams := kmip.CryptographicParameters{
-		DigitalSignatureAlgorithm: kmip.DigitalSignatureAlgorithmRSASSA_PSSPKCS_1v2_1,
+		DigitalSignatureAlgorithm: kmip.DigitalSignatureAlgorithmRSASSA_PSS,
 		// CryptographicAlgorithm: kmip.CryptographicAlgorithmRSA,
 		HashingAlgorithm: kmip.HashingAlgorithmSHA_256,
 		// PaddingMethod:          kmip.PaddingMethodPSS,

--- a/kmipclient/sign_verify.go
+++ b/kmipclient/sign_verify.go
@@ -444,14 +444,14 @@ func normalizeDSACryptoParams(cparams *kmip.CryptographicParameters) {
 		case kmip.PaddingMethodPKCS1V1_5:
 			switch cparams.HashingAlgorithm {
 			case kmip.HashingAlgorithmSHA_256:
-				cparams.DigitalSignatureAlgorithm = kmip.DigitalSignatureAlgorithmSHA_256WithRSAEncryptionPKCS_1v1_5
+				cparams.DigitalSignatureAlgorithm = kmip.DigitalSignatureAlgorithmSHA_256WithRSAEncryption
 			case kmip.HashingAlgorithmSHA_384:
-				cparams.DigitalSignatureAlgorithm = kmip.DigitalSignatureAlgorithmSHA_384WithRSAEncryptionPKCS_1v1_5
+				cparams.DigitalSignatureAlgorithm = kmip.DigitalSignatureAlgorithmSHA_384WithRSAEncryption
 			case kmip.HashingAlgorithmSHA_512:
-				cparams.DigitalSignatureAlgorithm = kmip.DigitalSignatureAlgorithmSHA_512WithRSAEncryptionPKCS_1v1_5
+				cparams.DigitalSignatureAlgorithm = kmip.DigitalSignatureAlgorithmSHA_512WithRSAEncryption
 			}
 		case kmip.PaddingMethodPSS:
-			cparams.DigitalSignatureAlgorithm = kmip.DigitalSignatureAlgorithmRSASSA_PSSPKCS_1v2_1
+			cparams.DigitalSignatureAlgorithm = kmip.DigitalSignatureAlgorithmRSASSA_PSS
 		}
 	case kmip.CryptographicAlgorithmEC, kmip.CryptographicAlgorithmECDSA:
 		switch cparams.HashingAlgorithm {


### PR DESCRIPTION
Fixes #41 