### PR TITLE
fix: prevent nil pointer panics in UsageLimits, DialCluster, and bytesToBigInt

### DIFF
--- a/kmip.go
+++ b/kmip.go
@@ -180,7 +180,8 @@ func (ul UsageLimits) Equals(other *UsageLimits) bool {
 		other.UsageLimitsTotal == ul.UsageLimitsTotal &&
 		other.UsageLimitsUnit == ul.UsageLimitsUnit &&
 		(other.UsageLimitsCount == nil && ul.UsageLimitsCount == nil ||
-			*other.UsageLimitsCount == *ul.UsageLimitsCount)
+			other.UsageLimitsCount != nil && ul.UsageLimitsCount != nil &&
+				*other.UsageLimitsCount == *ul.UsageLimitsCount)
 }
 
 // KMIP 1.1.

--- a/kmipclient/dialer_cluster.go
+++ b/kmipclient/dialer_cluster.go
@@ -52,7 +52,8 @@ func DialClusterContext(ctx context.Context, addrs []string, options ...Option) 
 	}
 
 	if opts.retryTimeout == nil {
-		*opts.retryTimeout = 5 * time.Second
+		timeout := 5 * time.Second
+		opts.retryTimeout = &timeout
 	}
 
 	dialer := opts.dialer

--- a/kmipclient/dialer_cluster_test.go
+++ b/kmipclient/dialer_cluster_test.go
@@ -184,6 +184,21 @@ func TestClientConnectionPool_AllDownError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDialCluster_DefaultRetryTimeout(t *testing.T) {
+	// Verify DialCluster does not panic when WithRetryTimeout is not provided.
+	h := &simpleHandler{}
+	addr, ca := kmiptest.NewServer(t, h)
+	h.id = addr
+
+	client, err := kmipclient.DialCluster([]string{addr},
+		kmipclient.WithRootCAPem([]byte(ca)),
+		// No WithRetryTimeout — exercises the default path
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	defer client.Close()
+}
+
 func TestClientConnectionPool_IntermittentRecovery(t *testing.T) {
 	// Start server with a reusable TLS listener (generate cert here so we can restart on same addr)
 	// generate cert

--- a/objects_test.go
+++ b/objects_test.go
@@ -343,6 +343,46 @@ func TestPrivateKey_RSA(t *testing.T) {
 	})
 }
 
+func TestUsageLimits_Equals(t *testing.T) {
+	count1 := int64(100)
+	count2 := int64(200)
+
+	t.Run("both nil counts", func(t *testing.T) {
+		a := UsageLimits{UsageLimitsTotal: 10, UsageLimitsUnit: UsageLimitsUnitByte}
+		b := UsageLimits{UsageLimitsTotal: 10, UsageLimitsUnit: UsageLimitsUnitByte}
+		require.True(t, a.Equals(&b))
+	})
+
+	t.Run("both non-nil equal counts", func(t *testing.T) {
+		a := UsageLimits{UsageLimitsTotal: 10, UsageLimitsCount: &count1}
+		b := UsageLimits{UsageLimitsTotal: 10, UsageLimitsCount: &count1}
+		require.True(t, a.Equals(&b))
+	})
+
+	t.Run("both non-nil different counts", func(t *testing.T) {
+		a := UsageLimits{UsageLimitsTotal: 10, UsageLimitsCount: &count1}
+		b := UsageLimits{UsageLimitsTotal: 10, UsageLimitsCount: &count2}
+		require.False(t, a.Equals(&b))
+	})
+
+	t.Run("receiver nil count other non-nil", func(t *testing.T) {
+		a := UsageLimits{UsageLimitsTotal: 10}
+		b := UsageLimits{UsageLimitsTotal: 10, UsageLimitsCount: &count1}
+		require.False(t, a.Equals(&b))
+	})
+
+	t.Run("receiver non-nil count other nil", func(t *testing.T) {
+		a := UsageLimits{UsageLimitsTotal: 10, UsageLimitsCount: &count1}
+		b := UsageLimits{UsageLimitsTotal: 10}
+		require.False(t, a.Equals(&b))
+	})
+
+	t.Run("other is nil", func(t *testing.T) {
+		a := UsageLimits{UsageLimitsTotal: 10}
+		require.False(t, a.Equals(nil))
+	})
+}
+
 func TestPrivateKey_ECDSA(t *testing.T) {
 	ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	t.Run("pkcs8", func(t *testing.T) {

--- a/ttlv/encoding_ttlv_test.go
+++ b/ttlv/encoding_ttlv_test.go
@@ -181,6 +181,13 @@ func (s *TtlvDecodingSuite) TestDecodeBigInteger() {
 	})
 }
 
+func TestBytesToBigInt_EmptySlice(t *testing.T) {
+	result := bytesToBigInt([]byte{})
+	if result != nil {
+		t.Errorf("expected nil for empty slice, got %v", result)
+	}
+}
+
 func (s *TtlvDecodingSuite) TestDecodeEnum() {
 	dec := decodeHex("42 00 20 | 05 | 00 00 00 04 | 00 00 00 FF 00 00 00 00")
 	v, err := dec.Enum(0, 0x420020)

--- a/ttlv/utils.go
+++ b/ttlv/utils.go
@@ -38,6 +38,9 @@ func bigIntToBytes(value *big.Int, padding int) (b []byte, padVal byte, padLen i
 }
 
 func bytesToBigInt(v []byte) *big.Int {
+	if len(v) == 0 {
+		return nil
+	}
 	if bits.LeadingZeros8(v[0]) > 0 {
 		// Positive integer
 		bv := big.NewInt(0).SetBytes(v)


### PR DESCRIPTION
## Summary

- **UsageLimits.Equals**: add nil guards on both `UsageLimitsCount` pointers before dereferencing — panics when only one side is nil
- **DialClusterContext**: allocate a new pointer for the default retry timeout instead of dereferencing a nil pointer — panics whenever `WithRetryTimeout` option is not provided
- **bytesToBigInt**: add empty slice check to prevent index-out-of-bounds panic on malformed TTLV BigInteger values

## Test plan

- [x] `go test -race ./...` passes