### PR TITLE
fix(ttlv): add bounds check in Bool decoder for malformed TTLV input

### DIFF
--- a/ttlv/encoding_ttlv.go
+++ b/ttlv/encoding_ttlv.go
@@ -272,6 +272,9 @@ func (dec *ttlvReader) Bool(tag int) (bool, error) {
 	if err := dec.assertType(TypeBoolean, tag); err != nil {
 		return false, err
 	}
+	if dec.len() < 8 {
+		return false, Errorf("invalid TTLV Boolean value length: got %d bytes, expected 8", dec.len())
+	}
 	v := dec.value()[7] != 0
 	return v, dec.Next()
 }

--- a/ttlv/encoding_ttlv_test.go
+++ b/ttlv/encoding_ttlv_test.go
@@ -203,6 +203,30 @@ func (s *TtlvDecodingSuite) TestDecodeBoolean() {
 	})
 }
 
+func (s *TtlvDecodingSuite) TestDecodeBooleanMalformedShortValue() {
+	// Boolean type (06) with declared length of 2 instead of 8
+	bytes, err := hex.DecodeString(strings.NewReplacer(" ", "", "|", "").Replace(
+		"42 00 20 | 06 | 00 00 00 02 | 00 01 00 00 00 00 00 00"))
+	s.Require().NoError(err)
+	reader, err := newTTLVReader(bytes)
+	s.Require().NoError(err)
+	_, err = reader.Bool(0x420020)
+	s.Error(err)
+	s.Contains(err.Error(), "invalid TTLV Boolean value length")
+}
+
+func (s *TtlvDecodingSuite) TestDecodeBooleanMalformedZeroLength() {
+	// Boolean type (06) with declared length of 0
+	bytes, err := hex.DecodeString(strings.NewReplacer(" ", "", "|", "").Replace(
+		"42 00 20 | 06 | 00 00 00 00 | 00 00 00 00 00 00 00 00"))
+	s.Require().NoError(err)
+	reader, err := newTTLVReader(bytes)
+	s.Require().NoError(err)
+	_, err = reader.Bool(0x420020)
+	s.Error(err)
+	s.Contains(err.Error(), "invalid TTLV Boolean value length")
+}
+
 func (s *TtlvDecodingSuite) TestDecodeTextString() {
 	dec := decodeHex("42 00 20 | 07 | 00 00 00 0B | 48 65 6C 6C 6F 20 57 6F 72 6C 64 00 00 00 00 00")
 	v, err := dec.TextString(0x420020)


### PR DESCRIPTION
## Summary

- Add length validation in the TTLV Bool decoder before accessing `value()[7]`. A malformed TTLV message with a Boolean type header but a declared value length shorter than 8 bytes would pass `assertType` validation but panic with an index-out-of-bounds error.

## Test plan

- [x] `go test -race ./...` passes