### PR TITLE
fix: correct misleading error messages

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -444,7 +444,7 @@ func test_register_rsa(client *kmipclient.Client) {
 		panic(err)
 	}
 	if !priv.Equal(rsaKey) {
-		panic("EC key not equal")
+		panic("RSA key not equal")
 	}
 }
 

--- a/payloads/get.go
+++ b/payloads/get.go
@@ -220,7 +220,7 @@ func (pl *GetResponsePayload) PublicKey() (crypto.PublicKey, error) {
 		CryptoPublicKey() (crypto.PublicKey, error)
 	})
 	if !ok {
-		return nil, fmt.Errorf("Object does not implement ECDSA() method")
+		return nil, fmt.Errorf("Object does not implement CryptoPublicKey() method")
 	}
 	return key.CryptoPublicKey()
 }


### PR DESCRIPTION
## Summary

- Fix incorrect error message in `GetResponsePayload.PublicKey()` that referenced `ECDSA()` instead of the actual `CryptoPublicKey()` interface method
- Fix wrong panic message in `test_register_rsa` example that said "EC key not equal" instead of "RSA key not equal"