### PR TITLE
fix: skip encoding nil ResponsePayload in response batch items

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -311,8 +311,8 @@ func register_split_key(client *kmipclient.Client) {
 		SplitKeyMethod:    kmip.SplitKeyMethodXOR,
 		KeyBlock: kmip.KeyBlock{
 			KeyFormatType:          kmip.KeyFormatTypeRaw,
-			CryptographicAlgorithm: alg,  // FIXME: If alg is null, Internal server error
-			CryptographicLength:    clen, // FIXME: Same here
+			CryptographicAlgorithm: alg,
+			CryptographicLength:    clen,
 			KeyValue: &kmip.KeyValue{
 				Plain: &kmip.PlainKeyValue{
 					KeyMaterial: kmip.KeyMaterial{Bytes: &[]byte{1, 2, 3, 4}},

--- a/responses.go
+++ b/responses.go
@@ -62,7 +62,9 @@ func (pv *ResponseBatchItem) TagEncodeTTLV(e *ttlv.Encoder, tag int) {
 		if len(pv.AsynchronousCorrelationValue) > 0 {
 			e.ByteString(TagAsynchronousCorrelationValue, pv.AsynchronousCorrelationValue)
 		}
-		e.TagAny(TagResponsePayload, pv.ResponsePayload)
+		if pv.ResponsePayload != nil {
+			e.TagAny(TagResponsePayload, pv.ResponsePayload)
+		}
 		if pv.MessageExtension != nil {
 			e.Any(pv.MessageExtension)
 		}


### PR DESCRIPTION
## Summary

- Add nil guard on `ResponsePayload` encoding in `ResponseBatchItem.TagEncodeTTLV()`, matching the existing pattern used for `MessageExtension`
- When `ResultStatus != Success`, the payload is typically nil — encoding a nil interface could produce unexpected TTLV output