### PR TITLE
feat: add configurable max message size for client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ client, err := kmipclient.Dial(
 	kmipclient.WithKmipVersions(kmip.V1_4, kmip.V1_3),     // Supported versions
 	kmipclient.EnforceVersion(kmip.V1_4),                   // Enforce specific version
 
-	// Message size limit (default: 1 MB, <= 0 disables)
+	// Message size limit (default: 1 MB, < 0 disables)
 	kmipclient.WithMaxMessageSize(2 * 1024 * 1024),         // 2 MB limit
 
 	// Middleware
@@ -470,7 +470,7 @@ func main() {
 	// Create and start server
 	handler := &MyKMIPHandler{}
 	server := kmipserver.NewServer(listener, handler).
-		WithMaxMessageSize(2 * 1024 * 1024) // 2 MB limit (default: 1 MB, <= 0 disables)
+		WithMaxMessageSize(2 * 1024 * 1024) // 2 MB limit (default: 1 MB, < 0 disables limit)
 
 	log.Println("Starting KMIP server on :5696")
 	if err := server.Serve(); err != nil {

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ client, err := kmipclient.Dial(
 	kmipclient.WithKmipVersions(kmip.V1_4, kmip.V1_3),     // Supported versions
 	kmipclient.EnforceVersion(kmip.V1_4),                   // Enforce specific version
 
+	// Message size limit (default: 1 MB, <= 0 disables)
+	kmipclient.WithMaxMessageSize(2 * 1024 * 1024),         // 2 MB limit
+
 	// Middleware
 	kmipclient.WithMiddlewares(
 		kmipclient.CorrelationValueMiddleware(uuid.NewString),
@@ -466,7 +469,8 @@ func main() {
 
 	// Create and start server
 	handler := &MyKMIPHandler{}
-	server := kmipserver.NewServer(listener, handler)
+	server := kmipserver.NewServer(listener, handler).
+		WithMaxMessageSize(2 * 1024 * 1024) // 2 MB limit (default: 1 MB, <= 0 disables)
 
 	log.Println("Starting KMIP server on :5696")
 	if err := server.Serve(); err != nil {

--- a/kmipclient/client.go
+++ b/kmipclient/client.go
@@ -68,8 +68,8 @@ type opts struct {
 	serverName        string
 	tlsCfg            *tls.Config
 	tlsCiphers        []uint16
-	dialer         DialerFunc
-	maxMessageSize int
+	dialer            DialerFunc
+	maxMessageSize    int
 	// For pool dialer
 	retryTimeout *time.Duration
 	//TODO: Add KMIP Authentication / Credentials
@@ -361,7 +361,7 @@ func WithDialerUnsafe(dialer DialerFunc) Option {
 
 // WithMaxMessageSize sets the maximum allowed size in bytes for a single KMIP message
 // received by the client. Messages exceeding this limit are rejected with an error.
-// A value <= 0 disables the limit. The default is 1 MB.
+// A value of 0 (or unset) uses the default (1 MB). A negative value disables the limit.
 func WithMaxMessageSize(size int) Option {
 	return func(o *opts) error {
 		o.maxMessageSize = size

--- a/kmipclient/client.go
+++ b/kmipclient/client.go
@@ -68,7 +68,8 @@ type opts struct {
 	serverName        string
 	tlsCfg            *tls.Config
 	tlsCiphers        []uint16
-	dialer            DialerFunc
+	dialer         DialerFunc
+	maxMessageSize int
 	// For pool dialer
 	retryTimeout *time.Duration
 	//TODO: Add KMIP Authentication / Credentials
@@ -358,6 +359,16 @@ func WithDialerUnsafe(dialer DialerFunc) Option {
 	}
 }
 
+// WithMaxMessageSize sets the maximum allowed size in bytes for a single KMIP message
+// received by the client. Messages exceeding this limit are rejected with an error.
+// A value <= 0 disables the limit. The default is 1 MB.
+func WithMaxMessageSize(size int) Option {
+	return func(o *opts) error {
+		o.maxMessageSize = size
+		return nil
+	}
+}
+
 // Client represents a KMIP client that manages a connection to a KMIP server,
 // handles protocol version negotiation, and supports middleware for request/response
 // processing. It provides thread-safe access to the underlying connection and
@@ -370,6 +381,7 @@ type Client struct {
 	dialer            DialerFunc
 	middlewares       []Middleware
 	addr              string
+	maxMessageSize    int
 }
 
 // Dial establishes a connection to the KMIP server at the specified address using the provided options.
@@ -403,6 +415,9 @@ func DialContext(ctx context.Context, addr string, options ...Option) (*Client, 
 	if len(opts.supportedVersions) == 0 {
 		opts.supportedVersions = append(opts.supportedVersions, supportedVersions...)
 	}
+	if opts.maxMessageSize == 0 {
+		opts.maxMessageSize = ttlv.DefaultMaxMessageSize
+	}
 
 	tlsCfg, err := opts.tlsConfig()
 	if err != nil {
@@ -426,12 +441,13 @@ func DialContext(ctx context.Context, addr string, options ...Option) (*Client, 
 
 	c := &Client{
 		lock:              new(sync.Mutex),
-		conn:              newConn(stream),
+		conn:              newConn(stream, opts.maxMessageSize),
 		dialer:            dialer,
 		supportedVersions: opts.supportedVersions,
 		version:           opts.enforceVersion,
 		middlewares:       opts.middlewares,
 		addr:              addr,
+		maxMessageSize:    opts.maxMessageSize,
 	}
 
 	// Negotiate protocol version
@@ -466,8 +482,9 @@ func (c *Client) CloneCtx(ctx context.Context) (*Client, error) {
 		supportedVersions: slices.Clone(c.supportedVersions),
 		dialer:            c.dialer,
 		middlewares:       slices.Clone(c.middlewares),
-		conn:              newConn(stream),
+		conn:              newConn(stream, c.maxMessageSize),
 		addr:              c.addr,
+		maxMessageSize:    c.maxMessageSize,
 	}, nil
 }
 
@@ -497,7 +514,7 @@ func (c *Client) reconnect(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	c.conn = newConn(stream)
+	c.conn = newConn(stream, c.maxMessageSize)
 	return nil
 }
 

--- a/kmipclient/client_test.go
+++ b/kmipclient/client_test.go
@@ -414,11 +414,25 @@ func TestWithMaxMessageSize(t *testing.T) {
 		require.Equal(t, "foobar", resp.UniqueIdentifier)
 	})
 
-	t.Run("no limit when set to zero", func(t *testing.T) {
+	t.Run("uses default when set to zero", func(t *testing.T) {
 		addr, ca := kmiptest.NewServer(t, mux)
 		client, err := kmipclient.Dial(addr,
 			kmipclient.WithRootCAPem([]byte(ca)),
 			kmipclient.WithMaxMessageSize(0),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = client.Close() })
+
+		resp, err := client.Activate("foobar").Exec()
+		require.NoError(t, err)
+		require.Equal(t, "foobar", resp.UniqueIdentifier)
+	})
+
+	t.Run("no limit when set to negative", func(t *testing.T) {
+		addr, ca := kmiptest.NewServer(t, mux)
+		client, err := kmipclient.Dial(addr,
+			kmipclient.WithRootCAPem([]byte(ca)),
+			kmipclient.WithMaxMessageSize(-1),
 		)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = client.Close() })

--- a/kmipclient/client_test.go
+++ b/kmipclient/client_test.go
@@ -381,6 +381,54 @@ func TestBatchResult_MustUnwrap_PanicsOnError(t *testing.T) {
 	})
 }
 
+func TestWithMaxMessageSize(t *testing.T) {
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(func(ctx context.Context, pl *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+		return &payloads.ActivateResponsePayload{UniqueIdentifier: pl.UniqueIdentifier}, nil
+	}))
+
+	t.Run("rejects response exceeding max size", func(t *testing.T) {
+		addr, ca := kmiptest.NewServer(t, mux)
+		// 16 bytes is too small for even the version negotiation response,
+		// so Dial itself should fail.
+		client, err := kmipclient.Dial(addr,
+			kmipclient.WithRootCAPem([]byte(ca)),
+			kmipclient.WithMaxMessageSize(16),
+		)
+		require.Error(t, err)
+		assert.Nil(t, client)
+		assert.True(t, ttlv.IsErrEncoding(err))
+	})
+
+	t.Run("accepts response within max size", func(t *testing.T) {
+		addr, ca := kmiptest.NewServer(t, mux)
+		client, err := kmipclient.Dial(addr,
+			kmipclient.WithRootCAPem([]byte(ca)),
+			kmipclient.WithMaxMessageSize(ttlv.DefaultMaxMessageSize),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = client.Close() })
+
+		resp, err := client.Activate("foobar").Exec()
+		require.NoError(t, err)
+		require.Equal(t, "foobar", resp.UniqueIdentifier)
+	})
+
+	t.Run("no limit when set to zero", func(t *testing.T) {
+		addr, ca := kmiptest.NewServer(t, mux)
+		client, err := kmipclient.Dial(addr,
+			kmipclient.WithRootCAPem([]byte(ca)),
+			kmipclient.WithMaxMessageSize(0),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = client.Close() })
+
+		resp, err := client.Activate("foobar").Exec()
+		require.NoError(t, err)
+		require.Equal(t, "foobar", resp.UniqueIdentifier)
+	})
+}
+
 func TestWithDialerUnsafe(t *testing.T) {
 	called := false
 	retErr := errors.New("not implemented")

--- a/kmipclient/conn.go
+++ b/kmipclient/conn.go
@@ -60,10 +60,10 @@ type conn struct {
 // Errors:
 //   - This function does not return errors directly. Errors may be encountered asynchronously
 //     in the readloop or writeloop goroutines if the network connection fails.
-func newConn(netCon net.Conn) *conn {
+func newConn(netCon net.Conn, maxMessageSize int) *conn {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	c := &conn{
-		stream: ttlv.NewStream(netCon, -1),
+		stream: ttlv.NewStream(netCon, maxMessageSize),
 		tx:     atomic.Value{},
 		rx:     make(chan rxMsg),
 		ctx:    ctx,

--- a/kmipclient/dialer_cluster.go
+++ b/kmipclient/dialer_cluster.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"github.com/ovh/kmip-go/ttlv"
 )
 
 type connectionEntry struct {
@@ -36,6 +38,9 @@ func DialClusterContext(ctx context.Context, addrs []string, options ...Option) 
 
 	if len(opts.supportedVersions) == 0 {
 		opts.supportedVersions = append(opts.supportedVersions, supportedVersions...)
+	}
+	if opts.maxMessageSize == 0 {
+		opts.maxMessageSize = ttlv.DefaultMaxMessageSize
 	}
 
 	tlsCfg, err := opts.tlsConfig()
@@ -97,12 +102,13 @@ func DialClusterContext(ctx context.Context, addrs []string, options ...Option) 
 
 	c := &Client{
 		lock:              new(sync.Mutex),
-		conn:              newConn(stream),
+		conn:              newConn(stream, opts.maxMessageSize),
 		dialer:            dialer,
 		supportedVersions: opts.supportedVersions,
 		version:           opts.enforceVersion,
 		middlewares:       opts.middlewares,
 		addr:              addrs[0],
+		maxMessageSize:    opts.maxMessageSize,
 	}
 
 	// Negotiate protocol version

--- a/kmipserver/conn.go
+++ b/kmipserver/conn.go
@@ -50,15 +50,14 @@ type conn struct {
 }
 
 // newConn initializes and returns a new conn instance for handling KMIP protocol communication.
-// It sets up the internal TTLV stream with a maximum size of 1 MB, initializes transmission and
+// It sets up the internal TTLV stream with the given maximum message size, initializes transmission and
 // reception channels, and starts the read and write loops in separate goroutines. The provided
 // context is wrapped to support cancellation with cause, and the given logger is used for logging.
 // The function is intended to be used for each new network connection.
-func newConn(netCon net.Conn, ctx context.Context, logger *slog.Logger) *conn {
+func newConn(netCon net.Conn, ctx context.Context, logger *slog.Logger, maxMessageSize int) *conn {
 	ctx, cancel := context.WithCancelCause(ctx)
 	c := &conn{
-		//TODO: Make max size configurable
-		stream: ttlv.NewStream(netCon, 1*1024*1024), // Max Size is 1 MB
+		stream: ttlv.NewStream(netCon, maxMessageSize),
 		tx:     atomic.Value{},
 		rx:     make(chan rxMsg),
 		ctx:    ctx,

--- a/kmipserver/http.go
+++ b/kmipserver/http.go
@@ -11,10 +11,10 @@ import (
 	"github.com/ovh/kmip-go/ttlv"
 )
 
-const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024 // Max body size is 1 MB
-
 // NewHTTPHandler creates a new HTTP handler that wraps the provided RequestHandler.
-// It returns an http.Handler that can be used to serve HTTP requests using the given handler logic.
+// It returns an *HTTPHandler that implements http.Handler and can be used to serve
+// HTTP requests using the given handler logic. The default max message size is
+// ttlv.DefaultMaxMessageSize (1 MB). Use WithMaxMessageSize to override.
 //
 // The method ServeHTTP handles incoming HTTP requests for the KMIP server. It supports POST requests with
 // Content-Type headers of "text/xml", "application/json", or "application/octet-stream", and
@@ -24,12 +24,25 @@ const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024 // Max body size is 1 MB
 // back. Only POST requests are allowed; other methods receive a 405 Method Not Allowed response.
 // Unsupported Content-Type headers result in a 406 Not Acceptable response, and requests with
 // invalid or missing Content-Length headers receive a 411 Length Required response.
-func NewHTTPHandler(hdl RequestHandler) http.Handler {
-	return httpHandler{inner: hdl}
+func NewHTTPHandler(hdl RequestHandler) *HTTPHandler {
+	return &HTTPHandler{inner: hdl, maxMessageSize: ttlv.DefaultMaxMessageSize}
 }
 
-type httpHandler struct {
-	inner RequestHandler
+// HTTPHandler is an http.Handler that serves KMIP requests over HTTP.
+type HTTPHandler struct {
+	inner          RequestHandler
+	maxMessageSize int
+}
+
+// WithMaxMessageSize sets the maximum allowed size in bytes for a single KMIP message
+// received by the HTTP handler. Messages exceeding this limit are rejected with HTTP 400.
+// A value of 0 uses the default ([ttlv.DefaultMaxMessageSize], 1 MB). A negative value disables the limit.
+func (hdl *HTTPHandler) WithMaxMessageSize(size int) *HTTPHandler {
+	if size == 0 {
+		size = ttlv.DefaultMaxMessageSize
+	}
+	hdl.maxMessageSize = size
+	return hdl
 }
 
 // ServeHTTP handles incoming HTTP requests for the KMIP server. It supports POST requests with
@@ -40,7 +53,7 @@ type httpHandler struct {
 // back. Only POST requests are allowed; other methods receive a 405 Method Not Allowed response.
 // Unsupported Content-Type headers result in a 406 Not Acceptable response, and requests with
 // invalid or missing Content-Length headers receive a 411 Length Required response.
-func (hdl httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+func (hdl HTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if body := req.Body; body != nil {
 		defer body.Close()
 	}
@@ -75,14 +88,19 @@ func (hdl httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusLengthRequired)
 		return
 	}
-	if contentLen > DEFAULT_MAX_BODY_SIZE {
+	if hdl.maxMessageSize > 0 && contentLen > hdl.maxMessageSize {
 		rw.WriteHeader(http.StatusBadRequest)
 		_, _ = io.WriteString(rw, "The request is too large")
 		return
 	}
 
+	body := io.Reader(req.Body)
+	if hdl.maxMessageSize > 0 {
+		body = io.LimitReader(body, int64(hdl.maxMessageSize)+1)
+	}
+
 	buf := make([]byte, contentLen)
-	if _, err := io.ReadFull(req.Body, buf); err != nil {
+	if _, err := io.ReadFull(body, buf); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
 		_, _ = io.WriteString(rw, "Amount of data is lower than Content-Length")
 		return
@@ -105,6 +123,6 @@ func (hdl httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (hdl httpHandler) handleError(ctx context.Context, err error, req *kmip.RequestMessage) *kmip.ResponseMessage {
+func (hdl HTTPHandler) handleError(ctx context.Context, err error, req *kmip.RequestMessage) *kmip.ResponseMessage {
 	return handleMessageError(ctx, req, err)
 }

--- a/kmipserver/http_test.go
+++ b/kmipserver/http_test.go
@@ -57,5 +57,51 @@ func TestHttpHandler_TTLV(t *testing.T) {
 			require.Equal(t, uid, resp.BatchItem[0].ResponsePayload.(*payloads.ActivateResponsePayload).UniqueIdentifier)
 		})
 	}
+}
 
+func TestHttpHandler_MaxMessageSize(t *testing.T) {
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(func(ctx context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+		return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+	}))
+
+	msg := kmip.NewRequestMessage(kmip.V1_4, &payloads.ActivateRequestPayload{UniqueIdentifier: "foobar"})
+	body := ttlv.MarshalTTLV(msg)
+
+	t.Run("rejects request exceeding max size", func(t *testing.T) {
+		hdl := kmipserver.NewHTTPHandler(mux).WithMaxMessageSize(16)
+
+		httpReq := httptest.NewRequest(http.MethodPost, "/kmip", bytes.NewReader(body))
+		httpReq.Header.Set("Content-Type", "application/octet-stream")
+		httpReq.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		rec := httptest.NewRecorder()
+		hdl.ServeHTTP(rec, httpReq)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		require.Contains(t, rec.Body.String(), "too large")
+	})
+
+	t.Run("accepts request within max size", func(t *testing.T) {
+		hdl := kmipserver.NewHTTPHandler(mux) // default 1 MB
+
+		httpReq := httptest.NewRequest(http.MethodPost, "/kmip", bytes.NewReader(body))
+		httpReq.Header.Set("Content-Type", "application/octet-stream")
+		httpReq.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		rec := httptest.NewRecorder()
+		hdl.ServeHTTP(rec, httpReq)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("no limit when set to negative", func(t *testing.T) {
+		hdl := kmipserver.NewHTTPHandler(mux).WithMaxMessageSize(-1)
+
+		httpReq := httptest.NewRequest(http.MethodPost, "/kmip", bytes.NewReader(body))
+		httpReq.Header.Set("Content-Type", "application/octet-stream")
+		httpReq.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		rec := httptest.NewRecorder()
+		hdl.ServeHTTP(rec, httpReq)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
 }

--- a/kmipserver/server.go
+++ b/kmipserver/server.go
@@ -130,8 +130,11 @@ func (srv *Server) WithTerminateHook(hook TerminateHook) *Server {
 
 // WithMaxMessageSize sets the maximum allowed size in bytes for a single KMIP message
 // received by the server. Messages exceeding this limit are rejected with an error.
-// A value <= 0 disables the limit. The default is 1 MB.
+// A value of 0 uses the default ([ttlv.DefaultMaxMessageSize], 1 MB). A negative value disables the limit.
 func (srv *Server) WithMaxMessageSize(size int) *Server {
+	if size == 0 {
+		size = ttlv.DefaultMaxMessageSize
+	}
 	srv.maxMessageSize = size
 	return srv
 }

--- a/kmipserver/server.go
+++ b/kmipserver/server.go
@@ -42,16 +42,17 @@ type TerminateHook func(context.Context)
 // hooks for connect and terminate events, allowing customization of behavior when a client
 // connects or disconnects.
 type Server struct {
-	listener   net.Listener
-	handler    RequestHandler
-	logger     *slog.Logger
-	ctx        context.Context
-	cancel     func()
-	recvCtx    context.Context
-	recvCancel func()
-	wg         *sync.WaitGroup
-	onConnect  ConnectHook
-	onClose    TerminateHook
+	listener       net.Listener
+	handler        RequestHandler
+	logger         *slog.Logger
+	ctx            context.Context
+	cancel         func()
+	recvCtx        context.Context
+	recvCancel     func()
+	wg             *sync.WaitGroup
+	onConnect      ConnectHook
+	onClose        TerminateHook
+	maxMessageSize int
 }
 
 // ConnectHook wraps the configured connectHook function, calling it with the provided context.
@@ -89,16 +90,15 @@ func NewServer(listener net.Listener, handler RequestHandler) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
 	recvCtx, recvCancel := context.WithCancel(context.Background())
 	return &Server{
-		listener,
-		handler,
-		slog.Default(),
-		ctx,
-		cancel,
-		recvCtx,
-		recvCancel,
-		new(sync.WaitGroup),
-		nil,
-		nil,
+		listener:       listener,
+		handler:        handler,
+		logger:         slog.Default(),
+		ctx:            ctx,
+		cancel:         cancel,
+		recvCtx:        recvCtx,
+		recvCancel:     recvCancel,
+		wg:             new(sync.WaitGroup),
+		maxMessageSize: ttlv.DefaultMaxMessageSize,
 	}
 }
 
@@ -125,6 +125,14 @@ func (srv *Server) WithConnectHook(hook ConnectHook) *Server {
 //   - The Server instance with the terminate hook set.
 func (srv *Server) WithTerminateHook(hook TerminateHook) *Server {
 	srv.onClose = hook
+	return srv
+}
+
+// WithMaxMessageSize sets the maximum allowed size in bytes for a single KMIP message
+// received by the server. Messages exceeding this limit are rejected with an error.
+// A value <= 0 disables the limit. The default is 1 MB.
+func (srv *Server) WithMaxMessageSize(size int) *Server {
+	srv.maxMessageSize = size
 	return srv
 }
 
@@ -188,7 +196,7 @@ func (srv *Server) handleConn(conn net.Conn) {
 		tlsState = new(tls.ConnectionState)
 		*tlsState = tcon.ConnectionState()
 	}
-	stream := newConn(conn, srv.ctx, logger)
+	stream := newConn(conn, srv.ctx, logger, srv.maxMessageSize)
 	// TODO: Save ref in server
 	// TODO: Remove ref on connection termination
 	defer stream.Close()

--- a/kmipserver/server_test.go
+++ b/kmipserver/server_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ovh/kmip-go"
+	"github.com/ovh/kmip-go/kmipclient"
 	"github.com/ovh/kmip-go/kmipserver"
 	"github.com/ovh/kmip-go/kmiptest"
 	"github.com/ovh/kmip-go/payloads"
@@ -126,6 +127,56 @@ func TestServerRequest_BadRequest(t *testing.T) {
 	require.Len(t, resp.BatchItem, 1)
 	require.Equal(t, kmip.ResultStatusOperationFailed, resp.BatchItem[0].ResultStatus)
 	require.Equal(t, kmip.ResultReasonInvalidMessage, resp.BatchItem[0].ResultReason)
+}
+
+func TestServerWithMaxMessageSize(t *testing.T) {
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(func(ctx context.Context, pl *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+		return &payloads.ActivateResponsePayload{UniqueIdentifier: pl.UniqueIdentifier}, nil
+	}))
+
+	t.Run("rejects request exceeding max size", func(t *testing.T) {
+		certPEM, keyPEM, err := kmiptest.GenerateSelfSignedCertPEM()
+		require.NoError(t, err)
+
+		ln, srvAddr := kmiptest.ListenWithCert(t, certPEM, keyPEM)
+		srv := kmipserver.NewServer(ln, mux).
+			WithMaxMessageSize(16) // too small for any real request
+
+		go func() { _ = srv.Serve() }()
+		t.Cleanup(func() { _ = srv.Shutdown() })
+
+		caPool := x509.NewCertPool()
+		caPool.AppendCertsFromPEM(certPEM)
+		conn, err := tls.Dial("tcp", srvAddr, &tls.Config{RootCAs: caPool})
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// Send a valid KMIP request that exceeds 16 bytes
+		stream := ttlv.NewStream(conn, -1)
+		msg := kmip.NewRequestMessage(kmip.V1_4, &payloads.ActivateRequestPayload{UniqueIdentifier: "foobar"})
+		err = stream.Send(&msg)
+		require.NoError(t, err)
+
+		// Server rejects the oversized message and returns an error response
+		resp := &kmip.ResponseMessage{}
+		err = stream.Recv(resp)
+		require.NoError(t, err)
+		require.Len(t, resp.BatchItem, 1)
+		require.Equal(t, kmip.ResultStatusOperationFailed, resp.BatchItem[0].ResultStatus)
+		require.Contains(t, resp.BatchItem[0].ResultMessage, "too big")
+	})
+
+	t.Run("accepts request within max size", func(t *testing.T) {
+		addr, ca := kmiptest.NewServer(t, mux) // default 1 MB
+		client, err := kmipclient.Dial(addr, kmipclient.WithRootCAPem([]byte(ca)))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = client.Close() })
+
+		resp, err := client.Activate("foobar").Exec()
+		require.NoError(t, err)
+		require.Equal(t, "foobar", resp.UniqueIdentifier)
+	})
 }
 
 func TestServerRequest_BadRequestMessageContent(t *testing.T) {

--- a/ttlv/io.go
+++ b/ttlv/io.go
@@ -36,7 +36,7 @@ func NewStream(inner io.ReadWriteCloser, maxSize int) Stream {
 	}
 }
 
-// Close wloses the inner stream.
+// Close closes the inner stream.
 func (s *Stream) Close() error {
 	if s.inner == nil {
 		return nil

--- a/ttlv/io.go
+++ b/ttlv/io.go
@@ -5,6 +5,9 @@ import (
 	"slices"
 )
 
+// DefaultMaxMessageSize is the default maximum allowed size in bytes for a single KMIP message.
+const DefaultMaxMessageSize = 1 * 1024 * 1024 // 1 MB
+
 // computeNeededBytes calculates the number of bytes needed to process a TTLV-encoded buffer.
 // If the buffer length is less than 8 bytes, it returns 8 as the minimum required size.
 // Otherwise, it returns 8 plus the padded length of the TTLV value as determined by ttlvReader.

--- a/ttlv/io_test.go
+++ b/ttlv/io_test.go
@@ -1,0 +1,54 @@
+package ttlv
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nopCloser wraps an io.ReadWriter to satisfy io.ReadWriteCloser.
+type nopCloser struct {
+	io.ReadWriter
+}
+
+func (nopCloser) Close() error { return nil }
+
+func TestStream_Recv_MaxMessageSize(t *testing.T) {
+	// Build a valid TTLV message: tag(3 bytes) + type(1 byte) + length(4 bytes) + value
+	enc := NewTTLVEncoder()
+	enc.TextString(0x42007c, "hello world")
+	data := enc.Bytes()
+
+	t.Run("rejected when message exceeds max size", func(t *testing.T) {
+		stream := NewStream(nopCloser{bytes.NewBuffer(data)}, 8) // limit smaller than message
+		var out any
+		err := stream.Recv(&out)
+		require.Error(t, err)
+		assert.True(t, IsErrEncoding(err))
+		assert.Contains(t, err.Error(), "too big")
+	})
+
+	t.Run("accepted when message fits max size", func(t *testing.T) {
+		stream := NewStream(nopCloser{bytes.NewBuffer(data)}, len(data)+100)
+		var out Value
+		err := stream.Recv(&out)
+		require.NoError(t, err)
+	})
+
+	t.Run("no limit when max size is zero", func(t *testing.T) {
+		stream := NewStream(nopCloser{bytes.NewBuffer(data)}, 0)
+		var out Value
+		err := stream.Recv(&out)
+		require.NoError(t, err)
+	})
+
+	t.Run("no limit when max size is negative", func(t *testing.T) {
+		stream := NewStream(nopCloser{bytes.NewBuffer(data)}, -1)
+		var out Value
+		err := stream.Recv(&out)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Context

The KMIP client had no maximum message size limit, meaning a malformed or malicious TTLV header with a huge length field could cause unbounded memory allocation on the client side. The server and HTTP handler each had hardcoded 1 MB limits that were not configurable.

## Summary

- Add `ttlv.DefaultMaxMessageSize` constant (1 MB) shared across client, server, and HTTP handler
- Add `kmipclient.WithMaxMessageSize(size int)` option to control the max received message size on the client (previously unlimited)
- Add `kmipserver.Server.WithMaxMessageSize(size int)` builder method to make the TCP server's limit configurable (previously hardcoded)
- Add `kmipserver.HTTPHandler.WithMaxMessageSize(size int)` builder method to make the HTTP handler's limit configurable (previously hardcoded via `DEFAULT_MAX_BODY_SIZE`)
- `NewHTTPHandler` now returns `*HTTPHandler` instead of `http.Handler` to enable the builder pattern (still satisfies `http.Handler`)
- All three default to 1 MB; `0` uses the default, `< 0` disables the limit
- Propagated through `Dial`, `DialCluster`, `Clone`, and `reconnect` on the client side
- HTTP handler wraps `req.Body` with `io.LimitReader` as defense-in-depth against spoofed `Content-Length` headers
- Add unit tests at all levels: `ttlv.Stream`, client integration, server integration, and HTTP handler
- Update README examples for both client and server