### PR TITLE
fix(ttlv): parse DateTime hex values with base 16 instead of base 10

### DIFF
--- a/ttlv/encoding_json.go
+++ b/ttlv/encoding_json.go
@@ -493,7 +493,7 @@ func (j *jsonReader) DateTime(tag int) (time.Time, error) {
 	switch val := j.getValue().(type) {
 	case string:
 		if strings.HasPrefix(val, "0x") {
-			parsed, err := strconv.ParseUint(val[2:], 10, 64)
+			parsed, err := strconv.ParseUint(val[2:], 16, 64)
 			if err != nil {
 				return time.Time{}, err
 			}

--- a/ttlv/encoding_json_test.go
+++ b/ttlv/encoding_json_test.go
@@ -368,6 +368,15 @@ func (s *JsonDecodingSuite) TestDecodeDateTime() {
 	s.EqualValues(time.Date(2008, time.March, 14, 11, 56, 40, 0, time.UTC), n.UTC())
 }
 
+func (s *JsonDecodingSuite) TestDecodeDateTimeHex() {
+	// 0x47DA67F8 == 1205495800 == 2008-03-14T11:56:40Z
+	data := `{"tag": "0x420020", "type": "DateTime", "value": "0x47DA67F8"}`
+	r := s.newReader(data)
+	n, err := r.DateTime(0x420020)
+	s.NoError(err)
+	s.EqualValues(time.Date(2008, time.March, 14, 11, 56, 40, 0, time.UTC), n.UTC())
+}
+
 func (s *JsonDecodingSuite) TestDecodeInterval() {
 	data := `{"tag": "0x420020", "type": "Interval", "value": 864000}`
 	r := s.newReader(data)


### PR DESCRIPTION
## Summary
- Fix `strconv.ParseUint` base parameter in `DateTime` JSON decoder: `0x`-prefixed values were parsed with base 10 instead of base 16, causing any value containing hex digits (a-f) to fail
- Add test case for hex-encoded DateTime decoding