### PR TITLE
fix: guard against nil KeyValue in KeyBlock accessors

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -519,7 +519,7 @@ func (kb *KeyBlock) TagDecodeTTLV(d *ttlv.Decoder, tag int) error {
 }
 
 func (kb *KeyBlock) GetMaterial() (KeyMaterial, error) {
-	if kb.KeyValue.Plain == nil {
+	if kb.KeyValue == nil || kb.KeyValue.Plain == nil {
 		return KeyMaterial{}, errors.New("Empty key value")
 	}
 	return kb.KeyValue.Plain.KeyMaterial, nil
@@ -537,7 +537,7 @@ func (kb *KeyBlock) GetBytes() ([]byte, error) {
 }
 
 func (kb *KeyBlock) GetAttributes() []Attribute {
-	if kb.KeyValue.Plain == nil {
+	if kb.KeyValue == nil || kb.KeyValue.Plain == nil {
 		return nil
 	}
 	return kb.KeyValue.Plain.Attribute

--- a/objects_test.go
+++ b/objects_test.go
@@ -48,6 +48,41 @@ func TestObject(t *testing.T) {
 	})
 }
 
+func TestKeyBlock_NilKeyValue(t *testing.T) {
+	t.Run("nil-KeyValue", func(t *testing.T) {
+		kb := KeyBlock{KeyFormatType: KeyFormatTypeRaw}
+		require.NotPanics(t, func() {
+			mat, err := kb.GetMaterial()
+			require.Error(t, err)
+			require.Zero(t, mat)
+		})
+		require.NotPanics(t, func() {
+			b, err := kb.GetBytes()
+			require.Error(t, err)
+			require.Nil(t, b)
+		})
+		require.NotPanics(t, func() {
+			require.Nil(t, kb.GetAttributes())
+		})
+	})
+	t.Run("nil-Plain", func(t *testing.T) {
+		kb := KeyBlock{KeyFormatType: KeyFormatTypeRaw, KeyValue: &KeyValue{}}
+		require.NotPanics(t, func() {
+			mat, err := kb.GetMaterial()
+			require.Error(t, err)
+			require.Zero(t, mat)
+		})
+		require.NotPanics(t, func() {
+			b, err := kb.GetBytes()
+			require.Error(t, err)
+			require.Nil(t, b)
+		})
+		require.NotPanics(t, func() {
+			require.Nil(t, kb.GetAttributes())
+		})
+	})
+}
+
 func TestSecretData_Data(t *testing.T) {
 	t.Run("raw", func(t *testing.T) {
 		data := []byte("foobar")


### PR DESCRIPTION
## Summary

`KeyBlock.KeyValue` is a pointer (`*KeyValue`) that can be nil for metadata-only objects, but `GetMaterial()` and `GetAttributes()` dereferenced `kb.KeyValue.Plain` without a nil check, panicking on such inputs.

Added a `kb.KeyValue != nil` guard to both methods. `GetBytes()` is covered transitively via `GetMaterial()`.