### PR TITLE
fix(ttlv): pad XML BigInteger to 8-byte boundary

### DIFF
--- a/ttlv/encoding_xml.go
+++ b/ttlv/encoding_xml.go
@@ -84,7 +84,7 @@ func (enc *xmlWriter) LongInteger(tag int, value int64) {
 }
 
 func (enc *xmlWriter) BigInteger(tag int, value *big.Int) {
-	bytes, pad, padLen := bigIntToBytes(value, 1)
+	bytes, pad, padLen := bigIntToBytes(value, 8)
 	val := bytes
 	if padLen > 0 {
 		val = make([]byte, padLen, len(bytes)+padLen)

--- a/ttlv/encoding_xml_test.go
+++ b/ttlv/encoding_xml_test.go
@@ -46,14 +46,14 @@ func (s *XmlEncodingSuite) TestEncodeBigInteger() {
 		b := big.NewInt(0)
 		b.SetString("1234567890000000000000000000", 10)
 		s.enc.BigInteger(0x420020, b)
-		expected := `<TTLV tag="0x420020" type="BigInteger" value="03FD35EB6BC2DF4618080000"/>`
+		expected := `<TTLV tag="0x420020" type="BigInteger" value="0000000003FD35EB6BC2DF4618080000"/>`
 		s.Equal(expected, string(s.enc.Bytes()))
 	})
 	s.Run("zero", func() {
 		s.enc.Clear()
 		b := big.NewInt(0)
 		s.enc.BigInteger(0x420020, b)
-		expected := `<TTLV tag="0x420020" type="BigInteger" value="00"/>`
+		expected := `<TTLV tag="0x420020" type="BigInteger" value="0000000000000000"/>`
 		s.Equal(expected, string(s.enc.Bytes()))
 	})
 	s.Run("negative", func() {
@@ -61,7 +61,7 @@ func (s *XmlEncodingSuite) TestEncodeBigInteger() {
 		b := big.NewInt(0)
 		b.SetString("-1234567890000000000000000000", 10)
 		s.enc.BigInteger(0x420020, b)
-		expected := `<TTLV tag="0x420020" type="BigInteger" value="FC02CA14943D20B9E7F80000"/>`
+		expected := `<TTLV tag="0x420020" type="BigInteger" value="FFFFFFFFFC02CA14943D20B9E7F80000"/>`
 		s.Equal(expected, string(s.enc.Bytes()))
 	})
 }
@@ -206,21 +206,21 @@ func (s *XmlDecodingSuite) TestDecodeLongInteger() {
 
 func (s *XmlDecodingSuite) TestDecodeBigInteger() {
 	s.Run("positive", func() {
-		data := `<TTLV tag="0x420020" type="BigInteger" value="03FD35EB6BC2DF4618080000"/>`
+		data := `<TTLV tag="0x420020" type="BigInteger" value="0000000003FD35EB6BC2DF4618080000"/>`
 		r := s.newReader(data)
 		n, err := r.BigInteger(0x420020)
 		s.NoError(err)
 		s.EqualValues("1234567890000000000000000000", n.String())
 	})
 	s.Run("zero", func() {
-		data := `<TTLV tag="0x420020" type="BigInteger" value="00"/>`
+		data := `<TTLV tag="0x420020" type="BigInteger" value="0000000000000000"/>`
 		r := s.newReader(data)
 		n, err := r.BigInteger(0x420020)
 		s.NoError(err)
 		s.EqualValues(0, n.Int64())
 	})
 	s.Run("negative", func() {
-		data := `<TTLV tag="0x420020" type="BigInteger" value="FC02CA14943D20B9E7F80000"/>`
+		data := `<TTLV tag="0x420020" type="BigInteger" value="FFFFFFFFFC02CA14943D20B9E7F80000"/>`
 		r := s.newReader(data)
 		n, err := r.BigInteger(0x420020)
 		s.NoError(err)


### PR DESCRIPTION
## Summary

The XML `BigInteger` encoder used `bigIntToBytes(value, 1)`, which only adds enough padding to preserve the sign bit. The OASIS KMIP XML profile expects `BigInteger` hex values to be zero-padded to a multiple of 8 bytes, matching the binary TTLV encoding (e.g. `value="0000000000010001"` for 65537).

Switch the XML writer to `bigIntToBytes(value, 8)` and update the test expectations to the 8-byte-aligned form.