### PR TITLE
feat(client)!: add KMIP-over-HTTPS transport via kmiphttp sub-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ See [KMIP v1.4 protocol specification](https://docs.oasis-open.org/kmip/spec/v1.
 - **Comprehensive Cryptographic Operations**: Key generation, encryption, decryption, signing, verification
 - **Flexible Authentication**: Mutual TLS, username/password, device, and attestation-based authentication
 - **TLS Security**: Built-in TLS support with client certificate authentication
+- **HTTPS Transport**: Optional KMIP-over-HTTPS with TTLV, XML, or JSON wire formats (opt-in sub-package)
 - **Batch Operations**: Support for batching multiple operations in a single request
 - **Middleware System**: Extensible middleware for logging, debugging, and custom functionality
 - **Go standard crypto compatible**: Implements crypto.Signer interface and support cryptographic key types from the standard library
@@ -129,6 +130,41 @@ client, err := kmipclient.Dial(
 	),
 )
 ```
+
+### HTTP Transport
+
+By default the client speaks KMIP's native TTLV-over-TLS stream protocol. For servers that expose KMIP over HTTPS, opt into the HTTP transport via the `kmipclient/kmiphttp` sub-package. Importing `kmipclient` alone does **not** link `net/http`; only callers that use `kmiphttp` pay that cost.
+
+```go
+import (
+	"github.com/ovh/kmip-go/kmipclient"
+	"github.com/ovh/kmip-go/kmipclient/kmiphttp"
+)
+```
+
+Requests are POSTed to `https://<addr><path>`; the standard TLS options apply unchanged. The scheme is hard-coded to `https`: pass a bare `host:port` (no `http://` or `https://` prefix), since HTTPS is implicit and a scheme prefix is rejected at `Dial` time.
+
+```go
+client, err := kmipclient.Dial(
+	"kms.example.com:5696",
+	kmiphttp.WithTransport("/kmip"),
+	kmipclient.WithClientCertFiles("cert.pem", "key.pem"),
+)
+```
+
+The default wire format is binary TTLV; pick XML or JSON with `kmiphttp.WithWireFormat`:
+
+```go
+client, err := kmipclient.Dial(
+	"kms.example.com:5696",
+	kmiphttp.WithTransport("/kmip",
+		kmiphttp.WithWireFormat(kmiphttp.WireJSON),
+	),
+	kmipclient.WithClientCertFiles("cert.pem", "key.pem"),
+)
+```
+
+Non-2xx responses are returned as a typed [`*kmiphttp.Error`](https://pkg.go.dev/github.com/ovh/kmip-go/kmipclient/kmiphttp#Error) carrying `StatusCode` and a bounded `Body` excerpt — use `errors.As` rather than matching on the error string. See the API docs for [`kmiphttp.WithHeader`](https://pkg.go.dev/github.com/ovh/kmip-go/kmipclient/kmiphttp#WithHeader) (custom headers) and [`kmiphttp.WithClient`](https://pkg.go.dev/github.com/ovh/kmip-go/kmipclient/kmiphttp#WithClient) (supplying your own `*http.Client`).
 
 ### Key Creation and Management
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -163,7 +163,7 @@ func discover(client *kmipclient.Client) {
 			ProtocolVersion: []kmip.ProtocolVersion{},
 		},
 	)
-	if _, err := client.Roundtrip(context.Background(), &msg); err != nil {
+	if _, err := client.RoundTrip(context.Background(), &msg); err != nil {
 		panic(err)
 	}
 }

--- a/kmip.go
+++ b/kmip.go
@@ -143,7 +143,7 @@ type Link struct {
 type Digest struct {
 	HashingAlgorithm HashingAlgorithm
 	DigestValue      []byte
-	KeyFormatType    KeyFormatType `ttlv:",omitempty,version=1.1.."`
+	KeyFormatType    KeyFormatType `ttlv:",omitempty,version=v1.1.."`
 }
 
 // Deprecated: deprecated as of kmip 1.1.

--- a/kmipclient/client.go
+++ b/kmipclient/client.go
@@ -45,11 +45,9 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"slices"
-	"sync"
 	"time"
 
 	"github.com/ovh/kmip-go"
@@ -70,6 +68,7 @@ type opts struct {
 	tlsCiphers        []uint16
 	dialer            DialerFunc
 	maxMessageSize    int
+	transportBuilder  TransportBuilder
 	// For pool dialer
 	retryTimeout *time.Duration
 	//TODO: Add KMIP Authentication / Credentials
@@ -81,22 +80,6 @@ func (o *opts) tlsConfig() (*tls.Config, error) {
 	if cfg == nil {
 		cfg = &tls.Config{
 			MinVersion: tls.VersionTLS12, // As required by KMIP 1.4 spec
-
-			// CipherSuites: []uint16{
-			// 	// Mandatory support as per KMIP 1.4 spec
-			// 	// tls.TLS_RSA_WITH_AES_256_CBC_SHA256, // Not supported in Go
-			// 	tls.TLS_RSA_WITH_AES_128_CBC_SHA256, // insecure
-
-			// 	// Optional support as per KMIP 1.4 spec
-			// 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			// 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			// 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			// 	tls.TLS_RSA_WITH_AES_128_CBC_SHA,            // insecure
-			// 	tls.TLS_RSA_WITH_AES_256_CBC_SHA,            // insecure
-			// 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, // insecure
-			// 	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,      // insecure
-			// 	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,   // insecure
-			// },
 		}
 	}
 	if cfg.RootCAs == nil {
@@ -126,7 +109,31 @@ func (o *opts) tlsConfig() (*tls.Config, error) {
 	return cfg, nil
 }
 
+// hasTLSOptions reports whether any of the standard TLS-related options have
+// been set. Exposed to transport builders via [DialInfo.TLSConfigured] for
+// mutual-exclusivity checks against fully-custom clients.
+func (o *opts) hasTLSOptions() bool {
+	return o.tlsCfg != nil ||
+		len(o.rootCAs) > 0 ||
+		len(o.certs) > 0 ||
+		o.serverName != "" ||
+		len(o.tlsCiphers) > 0
+}
+
 type Option func(*opts) error
+
+// applyOptions runs every option and joins any errors so the caller sees all
+// configuration mistakes at once instead of having to fix them one Dial at a
+// time.
+func applyOptions(o *opts, options []Option) error {
+	var errs []error
+	for _, opt := range options {
+		if err := opt(o); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
 
 // WithMiddlewares returns an Option that appends the provided Middleware(s) to the client's middleware chain.
 // This allows customization of the client's behavior by injecting additional processing steps.
@@ -343,12 +350,25 @@ func WithTlsCipherSuites(ciphers ...uint16) Option {
 	}
 }
 
-type DialerFunc func(ctx context.Context) (net.Conn, error)
+// DialerFunc establishes a (secured) network connection to addr. The same
+// DialerFunc may be invoked with different addresses across the lifetime of a
+// Client: DialCluster calls it once per cluster member, and the HTTP transport
+// calls it via http.Transport.DialTLSContext with the host:port resolved from
+// the request URL. Implementations must therefore honor the addr argument
+// rather than hard-coding a target.
+type DialerFunc func(ctx context.Context, addr string) (net.Conn, error)
 
 // WithDialerUnsafe customize the low-level network dialer used to establish the (secured) connection.
 //
-// When this option is provided, every other TLS related options are be ignored, and it's
-// the dialer responsibility to setup the secured channel using TLS or any other security mechanism.
+// When this option is provided, the standard kmipclient TLS options have no
+// effect on the established connection — it's the dialer's responsibility to
+// set up the secured channel using TLS or any other security mechanism. The
+// TLS options are still validated when applied (e.g. WithRootCAFile still
+// reads the file and may error at Dial time), they just don't shape the
+// connection.
+//
+// The dialer receives the per-call target address, so a single DialerFunc can
+// serve a cluster (DialCluster) or be wired into the HTTP transport's TLS dial.
 //
 // This option is a low-level escape hatch mainly used for testing or to provide alternative secured
 // channel implementation. Use at your own risks.
@@ -359,9 +379,19 @@ func WithDialerUnsafe(dialer DialerFunc) Option {
 	}
 }
 
-// WithMaxMessageSize sets the maximum allowed size in bytes for a single KMIP message
-// received by the client. Messages exceeding this limit are rejected with an error.
-// A value of 0 (or unset) uses the default (1 MB). A negative value disables the limit.
+// WithMaxMessageSize sets the maximum allowed size in bytes for a single KMIP
+// response received from the server. Both transports surface oversized
+// responses as [ErrResponseTooLarge] (use errors.Is to detect).
+//
+// Outbound requests are not capped on the client side — the caller is
+// responsible for sending sane payloads. The server may enforce its own
+// inbound cap, in which case an oversized request surfaces as a server-side
+// OperationFailed response, not as ErrResponseTooLarge.
+//
+// Values:
+//
+//   - 0 (or unset): use the default (1 MB).
+//   - Negative: disables the limit on both transports.
 func WithMaxMessageSize(size int) Option {
 	return func(o *opts) error {
 		o.maxMessageSize = size
@@ -369,19 +399,39 @@ func WithMaxMessageSize(size int) Option {
 	}
 }
 
+// WithTransportBuilder overrides the default TLS-stream transport. The builder
+// is invoked once during [DialContext] with the resolved [DialInfo] and its
+// result becomes the client's transport. Not compatible with [DialCluster],
+// which relies on the stream transport's per-address failover.
+//
+// This is the low-level integration hook used by transport sub-packages such
+// as [github.com/ovh/kmip-go/kmipclient/kmiphttp]; reach for it directly only
+// when implementing a brand-new transport.
+//
+// Implementations must satisfy the [Transport] contract — concurrency-safe
+// RoundTrip, independent Clone, idempotent Close — since [Client] relies on
+// those invariants.
+func WithTransportBuilder(b TransportBuilder) Option {
+	return func(o *opts) error {
+		if b == nil {
+			return errors.New("kmipclient: nil TransportBuilder")
+		}
+		o.transportBuilder = b
+		return nil
+	}
+}
+
 // Client represents a KMIP client that manages a connection to a KMIP server,
 // handles protocol version negotiation, and supports middleware for request/response
-// processing. It provides thread-safe access to the underlying connection and
-// configuration options such as supported protocol versions and custom dialers.
+// processing. The Client itself is read-only after construction; concurrency
+// safety (and serialization where needed, e.g. for the single-flight TTLV
+// stream protocol) is delegated to the underlying transport.
 type Client struct {
-	lock              *sync.Mutex
-	conn              *conn
+	tr                Transport
 	version           *kmip.ProtocolVersion
 	supportedVersions []kmip.ProtocolVersion
-	dialer            DialerFunc
 	middlewares       []Middleware
 	addr              string
-	maxMessageSize    int
 }
 
 // Dial establishes a connection to the KMIP server at the specified address using the provided options.
@@ -407,10 +457,8 @@ func Dial(addr string, options ...Option) (*Client, error) {
 //   - error   - An error if the connection or protocol negotiation fails.
 func DialContext(ctx context.Context, addr string, options ...Option) (*Client, error) {
 	opts := opts{}
-	for _, o := range options {
-		if err := o(&opts); err != nil {
-			return nil, err
-		}
+	if err := applyOptions(&opts, options); err != nil {
+		return nil, err
 	}
 	if len(opts.supportedVersions) == 0 {
 		opts.supportedVersions = append(opts.supportedVersions, supportedVersions...)
@@ -424,30 +472,17 @@ func DialContext(ctx context.Context, addr string, options ...Option) (*Client, 
 		return nil, err
 	}
 
-	dialer := opts.dialer
-	if dialer == nil {
-		dialer = func(ctx context.Context) (net.Conn, error) {
-			tlsDialer := tls.Dialer{
-				Config: tlsCfg,
-			}
-			return tlsDialer.DialContext(ctx, "tcp", addr)
-		}
-	}
-
-	stream, err := dialer(ctx)
+	tr, err := buildTransport(ctx, &opts, tlsCfg, addr)
 	if err != nil {
 		return nil, err
 	}
 
 	c := &Client{
-		lock:              new(sync.Mutex),
-		conn:              newConn(stream, opts.maxMessageSize),
-		dialer:            dialer,
+		tr:                tr,
 		supportedVersions: opts.supportedVersions,
 		version:           opts.enforceVersion,
 		middlewares:       opts.middlewares,
 		addr:              addr,
-		maxMessageSize:    opts.maxMessageSize,
 	}
 
 	// Negotiate protocol version
@@ -471,20 +506,17 @@ func (c *Client) Clone() (*Client, error) {
 //
 // Cloning a closed client is valid and will create a new connected client.
 func (c *Client) CloneCtx(ctx context.Context) (*Client, error) {
-	stream, err := c.dialer(ctx)
+	tr, err := c.tr.Clone(ctx)
 	if err != nil {
 		return nil, err
 	}
 	version := *c.version
 	return &Client{
-		lock:              new(sync.Mutex),
 		version:           &version,
 		supportedVersions: slices.Clone(c.supportedVersions),
-		dialer:            c.dialer,
 		middlewares:       slices.Clone(c.middlewares),
-		conn:              newConn(stream, c.maxMessageSize),
+		tr:                tr,
 		addr:              c.addr,
-		maxMessageSize:    c.maxMessageSize,
 	}, nil
 }
 
@@ -498,60 +530,18 @@ func (c *Client) Addr() string {
 	return c.addr
 }
 
-// Close terminates the client's connection and releases any associated resources.
-// It returns an error if the connection could not be closed.
+// Close releases the client's resources by delegating to the underlying
+// [Transport]'s Close. The default stream transport blocks until any in-flight
+// RoundTrip returns; cancel its context to abort sooner. Custom transports
+// (e.g. kmipclient/kmiphttp) may not cancel in-flight requests on Close —
+// see their own Close documentation.
 func (c *Client) Close() error {
-	return c.conn.Close()
+	return c.tr.Close()
 }
 
-func (c *Client) reconnect(ctx context.Context) error {
-	// fmt.Println("Reconnecting")
-	if c.conn != nil {
-		_ = c.conn.Close()
-		c.conn = nil
-	}
-	stream, err := c.dialer(ctx)
-	if err != nil {
-		return err
-	}
-	c.conn = newConn(stream, c.maxMessageSize)
-	return nil
-}
-
-// doRountrip sends a KMIP request message to the server and returns the corresponding response message.
-// It ensures thread safety by locking the client during the operation. If the connection is not established,
-// it attempts to reconnect. The method includes a retry mechanism for transient connection errors such as
-// io.EOF and io.ErrClosedPipe, attempting to reconnect and resend the request up to three times before failing.
-// Returns the response message on success, or an error if the operation ultimately fails.
-func (c *Client) doRountrip(ctx context.Context, msg *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.conn == nil {
-		if err := c.reconnect(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	//TODO: Better reconnection loop. Do we really need a retry counter here ?
-	retry := 3
-	for {
-		resp, err := c.conn.roundtrip(ctx, msg)
-		if err == nil {
-			return resp, nil
-		}
-		if retry <= 0 || (!errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe)) {
-			return nil, err
-		}
-		if err := c.reconnect(ctx); err != nil {
-			return nil, err
-		}
-		retry--
-	}
-}
-
-// Roundtrip sends a KMIP request message through the client's middleware chain and returns the response.
+// RoundTrip sends a KMIP request message through the client's middleware chain and returns the response.
 // Each middleware can process the request and response, or pass it along to the next middleware in the chain.
-// The final handler sends the request using the client's doRountrip method.
+// The final handler delegates to the underlying [Transport].
 //
 // Parameters:
 //
@@ -562,7 +552,7 @@ func (c *Client) doRountrip(ctx context.Context, msg *kmip.RequestMessage) (*kmi
 //
 //   - *kmip.ResponseMessage - The KMIP response message received.
 //   - error - Any error encountered during processing or sending the request.
-func (c *Client) Roundtrip(ctx context.Context, msg *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
+func (c *Client) RoundTrip(ctx context.Context, msg *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
 	i := 0
 	var next func(ctx context.Context, req *kmip.RequestMessage) (*kmip.ResponseMessage, error)
 	next = func(ctx context.Context, req *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
@@ -571,7 +561,7 @@ func (c *Client) Roundtrip(ctx context.Context, msg *kmip.RequestMessage) (*kmip
 			i++
 			return mdl(next, ctx, req)
 		}
-		return c.doRountrip(ctx, req)
+		return c.tr.RoundTrip(ctx, req)
 	}
 	return next(ctx, msg)
 }
@@ -593,7 +583,7 @@ func (c *Client) negotiateVersion(ctx context.Context) error {
 		ProtocolVersion: c.supportedVersions,
 	})
 
-	resp, err := c.Roundtrip(ctx, &msg)
+	resp, err := c.RoundTrip(ctx, &msg)
 	if err != nil {
 		return err
 	}
@@ -663,7 +653,7 @@ func (c *Client) Batch(ctx context.Context, payloads ...kmip.OperationPayload) (
 
 // BatchOpt sends a batch of KMIP operation payloads to the server and applies optional batch options.
 // It constructs a KMIP request message with the provided payloads and applies any BatchOption functions.
-// The request is sent using the client's Roundtrip method. If the response's batch count does not match
+// The request is sent using the client's RoundTrip method. If the response's batch count does not match
 // the number of payloads, an error is returned. On success, it returns the batch result items.
 //
 // Parameters:
@@ -679,7 +669,7 @@ func (c *Client) BatchOpt(ctx context.Context, payloads []kmip.OperationPayload,
 	for _, opt := range opts {
 		opt(&msg)
 	}
-	resp, err := c.Roundtrip(ctx, &msg)
+	resp, err := c.RoundTrip(ctx, &msg)
 	if err != nil {
 		return nil, err
 	}

--- a/kmipclient/client_test.go
+++ b/kmipclient/client_test.go
@@ -397,7 +397,7 @@ func TestWithMaxMessageSize(t *testing.T) {
 		)
 		require.Error(t, err)
 		assert.Nil(t, client)
-		assert.True(t, ttlv.IsErrEncoding(err))
+		assert.ErrorIs(t, err, kmipclient.ErrResponseTooLarge)
 	})
 
 	t.Run("accepts response within max size", func(t *testing.T) {
@@ -447,7 +447,7 @@ func TestWithDialerUnsafe(t *testing.T) {
 	called := false
 	retErr := errors.New("not implemented")
 	_, err := kmipclient.Dial("1.2.3.4", kmipclient.WithDialerUnsafe(
-		func(ctx context.Context) (net.Conn, error) {
+		func(ctx context.Context, _ string) (net.Conn, error) {
 			called = true
 			return nil, retErr
 		},

--- a/kmipclient/conn.go
+++ b/kmipclient/conn.go
@@ -126,13 +126,11 @@ func (c *conn) checkAvailable(ctx context.Context) error {
 // If an error occurs during reading, the connection is terminated and the loop exits.
 // The rx channel is closed when the loop exits.
 func (c *conn) readloop() {
-	// defer println("Exittig readloop")
 	defer close(c.rx)
 	for !c.closed.Load() {
 		msg := recvMsg{}
 		resp := rxMsg{}
 		if err := c.stream.Recv(&msg); err != nil {
-			// println("read fail:", resp.err.Error())
 			if errors.Is(err, net.ErrClosed) {
 				err = io.ErrClosedPipe
 			}
@@ -159,7 +157,6 @@ func (c *conn) readloop() {
 // It handles errors during sending, propagates them back to the requester, and terminates the connection if necessary.
 // The loop exits if the connection is closed, the context is done, or the transmission channel is closed.
 func (c *conn) writeloop() {
-	// defer println("Exittig writeloop")
 	tx := c.tx.Load().(chan txMsg)
 	for !c.closed.Load() {
 		select {
@@ -168,7 +165,6 @@ func (c *conn) writeloop() {
 				return
 			}
 			if err := c.stream.Send(req.msg); err != nil {
-				// println("write fail:", err.Error())
 				if errors.Is(err, net.ErrClosed) {
 					err = io.ErrClosedPipe
 				}

--- a/kmipclient/dialer_cluster.go
+++ b/kmipclient/dialer_cluster.go
@@ -2,7 +2,7 @@ package kmipclient
 
 import (
 	"context"
-	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -32,14 +32,18 @@ func DialCluster(addrs []string, options ...Option) (*Client, error) {
 
 func DialClusterContext(ctx context.Context, addrs []string, options ...Option) (*Client, error) {
 	if len(addrs) == 0 {
-		return nil, fmt.Errorf("at least one server address is required")
+		return nil, errors.New("at least one server address is required")
 	}
 
 	opts := opts{}
-	for _, o := range options {
-		if err := o(&opts); err != nil {
-			return nil, err
-		}
+	if err := applyOptions(&opts, options); err != nil {
+		return nil, err
+	}
+
+	// Custom transports have no cluster failover semantics; DialCluster relies
+	// on the stream transport's per-address dial loop.
+	if opts.transportBuilder != nil {
+		return nil, errors.New("custom transports are not supported with DialCluster; use Dial against a single endpoint instead")
 	}
 
 	if len(opts.supportedVersions) == 0 {
@@ -67,73 +71,66 @@ func DialClusterContext(ctx context.Context, addrs []string, options ...Option) 
 		opts.retryTimeout = &timeout
 	}
 
-	dialer := opts.dialer
-	if dialer == nil {
-		dialer = func(ctx context.Context) (net.Conn, error) {
-			tlsDialer := tls.Dialer{
-				Config: tlsCfg,
-			}
-			for _, s := range servers {
-				// TOCTOU: the lastError snapshot is released before DialContext and
-				// re-acquired only for the error write. Two goroutines can therefore
-				// dial the same server concurrently. This is intentional, holding the
-				// lock across I/O would serialize reconnections across cloned clients,
-				// and benign because the write is an idempotent time.Now() and the
-				// skip check is advisory.
-				s.mu.Lock()
-				if time.Since(s.lastError) < *opts.retryTimeout {
-					lastErr := s.lastError
-					s.mu.Unlock()
-					slog.Info("Skipping server because of recent last error", "url", s.url, "last_error", lastErr)
-					continue
-				}
+	dialOne := perAddrStreamDialer(opts.dialer, tlsCfg)
+
+	dialer := func(ctx context.Context) (net.Conn, error) {
+		for _, s := range servers {
+			// TOCTOU: the lastError snapshot is released before DialContext and
+			// re-acquired only for the error write. Two goroutines can therefore
+			// dial the same server concurrently. This is intentional, holding the
+			// lock across I/O would serialize reconnections across cloned clients,
+			// and benign because the write is an idempotent time.Now() and the
+			// skip check is advisory.
+			s.mu.Lock()
+			if time.Since(s.lastError) < *opts.retryTimeout {
+				lastErr := s.lastError
 				s.mu.Unlock()
-
-				conn, err := tlsDialer.DialContext(ctx, "tcp", s.url)
-				if err != nil {
-					now := time.Now()
-					s.mu.Lock()
-					s.lastError = now
-					s.mu.Unlock()
-					slog.Warn("TLS session initialization failed", "url", s.url, "error", err)
-				} else {
-					return conn, nil
-				}
+				slog.Info("Skipping server because of recent last error", "url", s.url, "last_error", lastErr)
+				continue
 			}
+			s.mu.Unlock()
 
-			// All servers have had an error within retryTimeout
-			// Call the first server to check if it went back up
-			first := servers[0]
-			conn, err := tlsDialer.DialContext(ctx, "tcp", first.url)
-			first.mu.Lock()
-
-			if err == nil {
-				// reset lastError since we had a success
-				first.lastError = time.Time{}
-				first.mu.Unlock()
+			conn, err := dialOne(ctx, s.url)
+			if err != nil {
+				now := time.Now()
+				s.mu.Lock()
+				s.lastError = now
+				s.mu.Unlock()
+				slog.Warn("Failed to dial server", "url", s.url, "error", err)
+			} else {
 				return conn, nil
 			}
-			first.lastError = time.Now()
-			first.mu.Unlock()
-			slog.Warn("TLS session initialization failed", "url", first.url, "error", err)
-			return nil, fmt.Errorf("failed to connect to servers in the connection pool (last attempt %q): %w", first.url, err)
 		}
+
+		// All servers have had an error within retryTimeout
+		// Call the first server to check if it went back up
+		first := servers[0]
+		conn, err := dialOne(ctx, first.url)
+		first.mu.Lock()
+
+		if err == nil {
+			// reset lastError since we had a success
+			first.lastError = time.Time{}
+			first.mu.Unlock()
+			return conn, nil
+		}
+		first.lastError = time.Now()
+		first.mu.Unlock()
+		slog.Warn("Failed to dial server", "url", first.url, "error", err)
+		return nil, fmt.Errorf("failed to connect to servers in the connection pool (last attempt %q): %w", first.url, err)
 	}
 
-	stream, err := dialer(ctx)
+	tr, err := newStreamTransport(ctx, dialer, opts.maxMessageSize)
 	if err != nil {
 		return nil, err
 	}
 
 	c := &Client{
-		lock:              new(sync.Mutex),
-		conn:              newConn(stream, opts.maxMessageSize),
-		dialer:            dialer,
+		tr:                tr,
 		supportedVersions: opts.supportedVersions,
 		version:           opts.enforceVersion,
 		middlewares:       opts.middlewares,
 		addr:              addrs[0],
-		maxMessageSize:    opts.maxMessageSize,
 	}
 
 	// Negotiate protocol version

--- a/kmipclient/dialer_cluster_test.go
+++ b/kmipclient/dialer_cluster_test.go
@@ -123,7 +123,7 @@ func TestClientNetworkConnection_Fallback(t *testing.T) {
 	req := kmip.NewRequestMessage(kmip.V1_4, &payloads.QueryRequestPayload{})
 
 	// first call should hit the first server
-	resp, err := client.Roundtrip(context.Background(), &req)
+	resp, err := client.RoundTrip(context.Background(), &req)
 	require.NoError(t, err)
 	require.Equal(t, addrs[0], resp.BatchItem[0].ResponsePayload.(*payloads.QueryResponsePayload).VendorIdentification)
 
@@ -134,7 +134,7 @@ func TestClientNetworkConnection_Fallback(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// next call should fallback to one of the remaining servers (addr[1] most likely)
-	resp2, err := client.Roundtrip(context.Background(), &req)
+	resp2, err := client.RoundTrip(context.Background(), &req)
 	require.NoError(t, err)
 	require.Equal(t, addrs[1], resp2.BatchItem[0].ResponsePayload.(*payloads.QueryResponsePayload).VendorIdentification)
 
@@ -144,7 +144,7 @@ func TestClientNetworkConnection_Fallback(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// next call should fallback to the last remaining server (addrs[2])
-	resp3, err := client.Roundtrip(context.Background(), &req)
+	resp3, err := client.RoundTrip(context.Background(), &req)
 	require.NoError(t, err)
 	require.Equal(t, addrs[2], resp3.BatchItem[0].ResponsePayload.(*payloads.QueryResponsePayload).VendorIdentification)
 }
@@ -164,7 +164,7 @@ func TestClientConnectionPool_PrimaryUpNoFallback(t *testing.T) {
 	require.NoError(t, err)
 
 	req := kmip.NewRequestMessage(kmip.V1_4, &payloads.QueryRequestPayload{})
-	resp, err := exec.Roundtrip(context.Background(), &req)
+	resp, err := exec.RoundTrip(context.Background(), &req)
 	require.NoError(t, err)
 	require.Equal(t, addrs[0], resp.BatchItem[0].ResponsePayload.(*payloads.QueryResponsePayload).VendorIdentification)
 }
@@ -280,7 +280,7 @@ func TestClientConnectionPool_IntermittentRecovery(t *testing.T) {
 
 	req := kmip.NewRequestMessage(kmip.V1_4, &payloads.QueryRequestPayload{})
 	// initial call should work
-	resp, err := exec.Roundtrip(context.Background(), &req)
+	resp, err := exec.RoundTrip(context.Background(), &req)
 	require.NoError(t, err)
 	require.Equal(t, addr, resp.BatchItem[0].ResponsePayload.(*payloads.QueryResponsePayload).VendorIdentification)
 
@@ -289,7 +289,7 @@ func TestClientConnectionPool_IntermittentRecovery(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// attempt should fail (single endpoint)
-	_, err = exec.Roundtrip(context.Background(), &req)
+	_, err = exec.RoundTrip(context.Background(), &req)
 	require.Error(t, err)
 
 	// restart server on same addr using same cert
@@ -298,14 +298,14 @@ func TestClientConnectionPool_IntermittentRecovery(t *testing.T) {
 	srv2 := kmipserver.NewServer(l2, h2)
 	go srv2.Serve()
 	// Retry before the timeout pass
-	resp2, err := exec.Roundtrip(context.Background(), &req)
+	resp2, err := exec.RoundTrip(context.Background(), &req)
 	require.NoError(t, err)
 	require.Equal(t, addr, resp2.BatchItem[0].ResponsePayload.(*payloads.QueryResponsePayload).VendorIdentification)
 
 	// give some time for client to consider endpoint retriable
 	time.Sleep(60 * time.Millisecond)
 
-	resp3, err := exec.Roundtrip(context.Background(), &req)
+	resp3, err := exec.RoundTrip(context.Background(), &req)
 	require.NoError(t, err)
 	require.Equal(t, addr, resp3.BatchItem[0].ResponsePayload.(*payloads.QueryResponsePayload).VendorIdentification)
 	_ = srv2.Shutdown()

--- a/kmipclient/kmiphttp/transport.go
+++ b/kmipclient/kmiphttp/transport.go
@@ -1,0 +1,548 @@
+// Package kmiphttp provides an HTTP(S) transport for [kmipclient]. It is an
+// optional sub-package: importing kmipclient alone does not pull in net/http.
+//
+// Typical usage:
+//
+//	client, err := kmipclient.Dial("kms.example.com:5696",
+//		kmiphttp.WithTransport("/kmip"),
+//		kmipclient.WithRootCAFile("ca.crt"),
+//	)
+//
+// HTTPS is unconditional; see [WithTransport] for the details.
+package kmiphttp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/ovh/kmip-go"
+	"github.com/ovh/kmip-go/kmipclient"
+	"github.com/ovh/kmip-go/ttlv"
+)
+
+const (
+	errorBodyExcerptMax = 4 * 1024
+	// errorBodyDrainCap bounds how much extra error-body we read after the
+	// excerpt so net/http can recycle the keep-alive connection. Without a cap a
+	// hostile server could force us to swallow an arbitrarily large error body.
+	errorBodyDrainCap = 64 * 1024
+)
+
+// WireFormat selects the on-the-wire encoding used by the HTTP transport when
+// exchanging KMIP messages with the server.
+type WireFormat int
+
+const (
+	// WireTTLV uses application/octet-stream and the TTLV binary encoding (default).
+	WireTTLV WireFormat = iota
+	// WireXML uses text/xml and the KMIP XML encoding.
+	WireXML
+	// WireJSON uses application/json and the KMIP JSON encoding.
+	WireJSON
+)
+
+func (f WireFormat) String() string {
+	switch f {
+	case WireTTLV:
+		return "TTLV"
+	case WireXML:
+		return "XML"
+	case WireJSON:
+		return "JSON"
+	default:
+		return fmt.Sprintf("WireFormat(%d)", int(f))
+	}
+}
+
+// Error is returned by the HTTP transport when the server replies with a
+// non-2xx status code. Body holds an excerpt of the response body (capped at
+// errorBodyExcerptMax bytes) for diagnostic purposes.
+type Error struct {
+	StatusCode int
+	Status     string
+	Body       []byte
+}
+
+func (e *Error) Error() string {
+	if len(e.Body) == 0 {
+		return fmt.Sprintf("kmip http: %s", e.Status)
+	}
+	// strconv.Quote so binary/non-printable bodies don't bleed raw bytes into logs.
+	return fmt.Sprintf("kmip http: %s: %s", e.Status, strconv.Quote(string(e.Body)))
+}
+
+// Option configures the HTTP transport. See [WithTransport].
+type Option func(*config) error
+
+// wireCodec bundles the content-type and (un)marshal functions for a single
+// WireFormat. Resolved eagerly at option-application time so the runtime path
+// never has to map a WireFormat to a codec (and never silently falls back to
+// TTLV on an unknown value).
+type wireCodec struct {
+	contentType string
+	marshal     func(any) []byte
+	unmarshal   func([]byte, any) error
+}
+
+var (
+	codecTTLV = wireCodec{"application/octet-stream", ttlv.MarshalTTLV, ttlv.UnmarshalTTLV}
+	codecXML  = wireCodec{"text/xml", ttlv.MarshalXML, ttlv.UnmarshalXML}
+	codecJSON = wireCodec{"application/json", ttlv.MarshalJSON, ttlv.UnmarshalJSON}
+)
+
+type config struct {
+	path       string
+	codec      wireCodec
+	client     *http.Client
+	header     http.Header
+	rtWrappers []func(http.RoundTripper) http.RoundTripper
+}
+
+// WithTransport selects the HTTP transport for the client. KMIP requests will
+// be POSTed to https://<addr><path>, where <addr> is the address passed to
+// [kmipclient.Dial] and <path> is the argument given here.
+//
+// HTTPS is unconditional: the URL scheme is hard-coded to "https://" and there
+// is no opt-in for plaintext HTTP. If you need to point a test at a non-TLS
+// server, supply a custom http.Client via [WithClient] whose RoundTripper
+// rewrites or otherwise routes the request.
+//
+// addr must be a bare host:port (e.g. "kms.example.com:5696"); supplying a
+// scheme — for example "https://host:5696" — is rejected at Dial time, since
+// concatenating it onto the implicit "https://" produces a confusing
+// https://https://… URL.
+//
+// path must start with "/". An empty string is normalized to "/". Paths may
+// not contain a fragment or a query string — both are almost certainly
+// copy-paste mistakes (fragments are silently stripped from the request
+// line; KMIP-over-HTTPS has no defined query semantics).
+//
+// TLS settings configured via the standard kmipclient TLS options
+// ([kmipclient.WithRootCAFile], [kmipclient.WithRootCAPem],
+// [kmipclient.WithClientCertFiles], [kmipclient.WithClientCertPEM],
+// [kmipclient.WithTlsConfig], [kmipclient.WithTlsCipherSuites],
+// [kmipclient.WithServerName]) are automatically applied to the underlying
+// http.Transport.
+//
+// If [kmipclient.WithDialerUnsafe] is set, the provided
+// [kmipclient.DialerFunc] is used to establish the (already-secured)
+// connection and the standard TLS configuration is bypassed — the dialer is
+// responsible for negotiating TLS itself.
+//
+// Use [WithClient] to fully override the *http.Client. WithClient is mutually
+// exclusive with [kmipclient.WithDialerUnsafe] and with the standard TLS
+// options listed above; configure TLS and dialing on the supplied client
+// instead.
+//
+// Errors from kmiphttp options aggregate among themselves (so a misconfigured
+// path, header key, and wire format are reported together), but they surface
+// only after kmipclient.Option errors have cleared — a misconfigured kmipclient
+// option short-circuits Dial before the transport builder runs, so the kmiphttp
+// errors won't show up until that's fixed.
+func WithTransport(path string, opts ...Option) kmipclient.Option {
+	// Build per-Dial so concurrent Dials reusing the same Option value don't
+	// share the config (and its header map).
+	return kmipclient.WithTransportBuilder(func(_ context.Context, info kmipclient.DialInfo) (kmipclient.Transport, error) {
+		cfg, err := newConfig(path, opts)
+		if err != nil {
+			return nil, err
+		}
+		return build(cfg, info)
+	})
+}
+
+// newConfig normalizes path and applies every option, surfacing all errors at
+// once via errors.Join.
+func newConfig(path string, opts []Option) (*config, error) {
+	var errs []error
+	if path == "" {
+		path = "/"
+	}
+	// All three checks run independently so a single Dial reports every
+	// problem with the path. "/" passes all of them, so the empty-string
+	// normalization above is safe.
+	if !strings.HasPrefix(path, "/") {
+		errs = append(errs, fmt.Errorf("kmip http: invalid path %q: must start with '/'", path))
+	}
+	// net/http silently strips fragments from the request line, which would
+	// mask a copy-paste mistake like "/kmip#frag".
+	if strings.Contains(path, "#") {
+		errs = append(errs, fmt.Errorf("kmip http: invalid path %q: must not contain a fragment", path))
+	}
+	// KMIP-over-HTTPS has no query semantics; query strings DO survive on the
+	// wire (unlike fragments), so a path like "/kmip?foo=bar" would silently
+	// send the query string on every POST. Reject at build time.
+	if strings.Contains(path, "?") {
+		errs = append(errs, fmt.Errorf("kmip http: invalid path %q: must not contain a query string", path))
+	}
+	cfg := &config{
+		path:   path,
+		codec:  codecTTLV,
+		header: http.Header{},
+	}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// WithWireFormat sets the on-the-wire encoding (TTLV binary, XML, or JSON).
+// Default is [WireTTLV]. The codec is resolved here, so an invalid value
+// fails at option-application time rather than silently degrading at runtime.
+func WithWireFormat(f WireFormat) Option {
+	return func(c *config) error {
+		switch f {
+		case WireTTLV:
+			c.codec = codecTTLV
+		case WireXML:
+			c.codec = codecXML
+		case WireJSON:
+			c.codec = codecJSON
+		default:
+			return fmt.Errorf("kmip http: invalid wire format %d", f)
+		}
+		return nil
+	}
+}
+
+// WithClient overrides the http.Client used by the HTTP transport. When set,
+// the supplied client is used as-is, so the standard kmipclient TLS options
+// ([kmipclient.WithRootCAFile], [kmipclient.WithRootCAPem],
+// [kmipclient.WithClientCertFiles], [kmipclient.WithClientCertPEM],
+// [kmipclient.WithTlsConfig], [kmipclient.WithTlsCipherSuites],
+// [kmipclient.WithServerName]) and [kmipclient.WithDialerUnsafe] would be
+// silently ignored — combining any of them with WithClient therefore returns
+// an error at Dial time. Configure TLS, dialing, and transport-level
+// pooling/timeouts on the supplied client instead.
+//
+// The bare-host:port shape check on addr still applies: even if the supplied
+// client's RoundTripper rewrites the request URL, addr must not include a
+// "scheme://" prefix, since the transport composes the request URL as
+// "https://<addr><path>" before invoking the client.
+//
+// If you only need to wrap the kmipclient-built RoundTripper (for tracing,
+// request signing, retries, …) while keeping kmipclient's TLS plumbing, prefer
+// [WrapRoundTripper] over a fully custom client.
+//
+// The supplied client's CheckRedirect policy is preserved as-is; the transport
+// does not override it. The kmipclient-built client refuses to follow 3xx
+// responses by default, so callers replacing it with WithClient who want the
+// same behavior must set [http.ErrUseLastResponse] (or an equivalent) on
+// their own client.
+func WithClient(client *http.Client) Option {
+	return func(c *config) error {
+		if client == nil {
+			return errors.New("kmip http: nil http.Client")
+		}
+		c.client = client
+		return nil
+	}
+}
+
+// WrapRoundTripper installs a wrapper around the http.RoundTripper used by
+// the HTTP transport. The supplied function receives the kmipclient-built
+// RoundTripper (with auto-configured TLS, dialer, and connection pooling) and
+// returns a wrapped RoundTripper. This is the recommended way to add tracing,
+// request signing, retries, or any other cross-cutting HTTP concern without
+// giving up the TLS configuration that the standard kmipclient TLS options
+// provide.
+//
+// Multiple wrappers may be registered by calling WrapRoundTripper more than
+// once. They are applied so that the first wrapper registered is the
+// outermost: it sees the request first and the response last, mirroring the
+// convention used by most Go HTTP middleware libraries.
+//
+// Mutually exclusive with [WithClient].
+func WrapRoundTripper(wrap func(http.RoundTripper) http.RoundTripper) Option {
+	return func(c *config) error {
+		if wrap == nil {
+			return errors.New("kmip http: nil RoundTripper wrapper")
+		}
+		c.rtWrappers = append(c.rtWrappers, wrap)
+		return nil
+	}
+}
+
+// WithHeader appends an extra header that will be sent on every KMIP request.
+// Reserved headers are rejected because the transport sets them itself, or
+// because net/http manages them via dedicated fields and would silently drop
+// a header-map entry:
+//
+//   - Content-Type, Accept: set by the transport per wire codec.
+//   - Content-Length: net/http writes it from req.ContentLength; a header-map
+//     entry is excluded by reqWriteExcludeHeader.
+//   - Host: net/http writes it from req.Host; a header-map entry is silently
+//     dropped on outbound requests.
+//   - Transfer-Encoding, Trailer: managed by net/http (chunked framing,
+//     trailing headers); also excluded by reqWriteExcludeHeader.
+//
+// User-Agent is intentionally NOT reserved: net/http excludes it from generic
+// header serialization but still emits it from req.Header["User-Agent"] as a
+// dedicated line, so a user-supplied value overrides the default.
+func WithHeader(key, value string) Option {
+	return func(c *config) error {
+		if key == "" {
+			return errors.New("kmip http: empty header key")
+		}
+		switch http.CanonicalHeaderKey(key) {
+		case "Content-Type", "Accept", "Content-Length", "Host",
+			"Transfer-Encoding", "Trailer":
+			return fmt.Errorf("kmip http: header %q is reserved and cannot be set via WithHeader", key)
+		}
+		c.header.Add(key, value)
+		return nil
+	}
+}
+
+// noFollowRedirect causes [http.Client] to surface a 3xx response as-is,
+// which our non-2xx branch then turns into a [*Error]. KMIP-over-HTTPS has no
+// redirect semantics in the spec; following a redirect could send credentials
+// or request bodies to an unintended host.
+func noFollowRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+// build returns a [transport] whose *http.Client is shared with any future
+// Clone, so cloned Clients reuse the underlying connection pool.
+func build(cfg *config, info kmipclient.DialInfo) (kmipclient.Transport, error) {
+	if err := validateAddr(info.Addr); err != nil {
+		return nil, err
+	}
+	reqURL, err := buildRequestURL(info.Addr, cfg.path)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.client != nil {
+		if info.Dialer != nil {
+			return nil, errors.New("kmip http: WithClient and WithDialerUnsafe are mutually exclusive; configure the dialer on the supplied http.Client instead")
+		}
+		if info.TLSConfigured {
+			return nil, errors.New("kmip http: WithClient is mutually exclusive with the standard TLS options (WithRootCAFile/Pem, WithClientCertFiles/PEM, WithTlsConfig, WithTlsCipherSuites, WithServerName); configure TLS on the supplied http.Client instead")
+		}
+		if len(cfg.rtWrappers) > 0 {
+			return nil, errors.New("kmip http: WrapRoundTripper and WithClient are mutually exclusive; wrap the supplied client's Transport instead")
+		}
+	}
+
+	client := cfg.client
+	if client == nil {
+		var tr *http.Transport
+		if base, ok := http.DefaultTransport.(*http.Transport); ok {
+			tr = base.Clone()
+		} else {
+			tr = &http.Transport{}
+		}
+		if info.Dialer != nil {
+			tr.TLSClientConfig = nil
+			dialer := info.Dialer
+			tr.DialTLSContext = func(ctx context.Context, _, addr string) (net.Conn, error) {
+				return dialer(ctx, addr)
+			}
+		} else {
+			tr.TLSClientConfig = info.TLSConfig
+		}
+		// Apply wrappers in reverse so the first registered ends up outermost
+		// (caller-side first), matching the convention of most Go HTTP
+		// middleware libraries.
+		var rt http.RoundTripper = tr
+		for i := len(cfg.rtWrappers) - 1; i >= 0; i-- {
+			rt = cfg.rtWrappers[i](rt)
+			if rt == nil {
+				return nil, fmt.Errorf("kmip http: WrapRoundTripper wrapper #%d returned nil", i)
+			}
+		}
+		client = &http.Client{
+			Transport:     rt,
+			CheckRedirect: noFollowRedirect,
+		}
+	}
+
+	return &transport{
+		client:     client,
+		url:        reqURL,
+		codec:      cfg.codec,
+		maxMsgSize: info.MaxMessageSize,
+		header:     cfg.header,
+	}, nil
+}
+
+// buildRequestURL composes "https://<addr><path>" and parses it once so
+// malformed paths (e.g. control characters) fail at Dial time instead of at
+// the first RoundTrip. Fragment/query rejection lives in newConfig so it
+// aggregates with other path/option errors (url.Parse accepts both).
+//
+// We deliberately return the raw concatenation rather than parsed.String():
+// newConfig has already validated the path byte-for-byte, and round-tripping
+// through *url.URL could re-encode characters in ways the caller didn't
+// write. url.Parse here is used purely as a validator.
+func buildRequestURL(addr, path string) (string, error) {
+	raw := "https://" + addr + path
+	if _, err := url.Parse(raw); err != nil {
+		// *url.Error already includes the URL in its message.
+		return "", fmt.Errorf("kmip http: %w", err)
+	}
+	return raw, nil
+}
+
+// validateAddr rejects addresses that don't look like a bare host:port, most
+// notably anything with a "scheme://" prefix — concatenating that with
+// "https://" produces a confusing https://https://… URL whose failure mode is
+// hard to diagnose. We use net.SplitHostPort for the host:port shape check,
+// which also handles bracketed IPv6 literals correctly.
+func validateAddr(addr string) error {
+	if strings.Contains(addr, "://") {
+		return fmt.Errorf("kmip http: addr %q must be a bare host:port (no scheme); HTTPS is implied", addr)
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("kmip http: invalid addr %q: %w", addr, err)
+	}
+	if host == "" || port == "" {
+		return fmt.Errorf("kmip http: invalid addr %q: host and port are required", addr)
+	}
+	return nil
+}
+
+// transport implements [kmipclient.Transport] over HTTP(S). The shared
+// *http.Client is concurrent-safe, so callers can issue parallel requests
+// without external serialization.
+type transport struct {
+	client     *http.Client
+	url        string
+	codec      wireCodec
+	maxMsgSize int
+	header     http.Header
+	closed     atomic.Bool
+}
+
+func (h *transport) RoundTrip(ctx context.Context, msg *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
+	if h.closed.Load() {
+		return nil, net.ErrClosed
+	}
+	body := h.codec.marshal(msg)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	// Clone (not shallow copy): downstream RoundTrippers may mutate header
+	// slices via append, which would race across concurrent requests. When no
+	// custom headers are configured, http.NewRequestWithContext has already
+	// initialized req.Header.
+	if len(h.header) > 0 {
+		req.Header = h.header.Clone()
+	}
+	req.Header.Set("Content-Type", h.codec.contentType)
+	req.Header.Set("Accept", h.codec.contentType)
+	req.ContentLength = int64(len(body))
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// io.ReadAll returns the partial read alongside any error, so even on
+		// a truncated body we surface a typed *Error: callers losing the
+		// StatusCode just because the excerpt read failed would be a worse
+		// diagnostic than handing them a short Body.
+		bodyExcerpt, readErr := io.ReadAll(io.LimitReader(resp.Body, errorBodyExcerptMax))
+		hErr := &Error{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       bodyExcerpt,
+		}
+		if readErr != nil {
+			// Skip the drain: if the excerpt read failed, draining is unlikely
+			// to succeed either, and the deferred Close() will tear down the
+			// connection rather than recycle it.
+			return nil, errors.Join(hErr, readErr)
+		}
+		// Drain bounded so net/http can recycle the keep-alive connection;
+		// without a cap a giant error body would block us reading it in full.
+		// If overflow remains the deferred Close() simply tears down the conn.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errorBodyDrainCap))
+		return nil, hErr
+	}
+
+	respBody, err := readBounded(resp, h.maxMsgSize)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &kmip.ResponseMessage{}
+	if err := h.codec.unmarshal(respBody, out); err != nil {
+		return nil, fmt.Errorf("kmip http: decode response: %w", err)
+	}
+	return out, nil
+}
+
+// Close marks this transport closed; subsequent RoundTrip calls return
+// net.ErrClosed. It does NOT cancel in-flight requests — callers must cancel
+// their request contexts to unblock pending roundtrips. The shared
+// *http.Client is intentionally not torn down so cloned clients keep pooling
+// connections; pass your own client via [WithClient] if you need explicit
+// lifecycle control.
+func (h *transport) Close() error {
+	h.closed.Store(true)
+	return nil
+}
+
+// Clone returns a fresh transport that shares the underlying *http.Client
+// (and therefore the connection pool) with the receiver. The clone has its
+// own closed-flag, so closing one does not affect the other. The header map
+// is shared too — it is treated as read-only after construction; RoundTrip
+// clones it per request before mutating.
+func (h *transport) Clone(_ context.Context) (kmipclient.Transport, error) {
+	return &transport{
+		client:     h.client,
+		url:        h.url,
+		codec:      h.codec,
+		maxMsgSize: h.maxMsgSize,
+		header:     h.header,
+	}, nil
+}
+
+// readBounded reads resp.Body, capping the read at maxSize bytes when maxSize > 0
+// (returning [kmipclient.ErrResponseTooLarge] if exceeded). When the server
+// sends a usable Content-Length the buffer is pre-sized and read in one shot
+// to avoid io.ReadAll's growth churn.
+func readBounded(resp *http.Response, maxSize int) ([]byte, error) {
+	if cl := resp.ContentLength; cl > 0 && (maxSize <= 0 || cl <= int64(maxSize)) {
+		// resp.Body is already capped by Content-Length; ReadFull both
+		// pre-sizes the slice and surfaces a short body as ErrUnexpectedEOF
+		// instead of silently truncating.
+		buf := make([]byte, cl)
+		if _, err := io.ReadFull(resp.Body, buf); err != nil {
+			return nil, err
+		}
+		return buf, nil
+	}
+	var reader io.Reader = resp.Body
+	if maxSize > 0 {
+		reader = io.LimitReader(resp.Body, int64(maxSize)+1)
+	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	if maxSize > 0 && len(body) > maxSize {
+		return nil, kmipclient.ErrResponseTooLarge
+	}
+	return body, nil
+}

--- a/kmipclient/kmiphttp/transport_test.go
+++ b/kmipclient/kmiphttp/transport_test.go
@@ -1,0 +1,808 @@
+package kmiphttp_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ovh/kmip-go"
+	"github.com/ovh/kmip-go/kmipclient"
+	"github.com/ovh/kmip-go/kmipclient/kmiphttp"
+	"github.com/ovh/kmip-go/kmipserver"
+	"github.com/ovh/kmip-go/payloads"
+	"github.com/ovh/kmip-go/ttlv"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newHTTPSTestServer wraps the given handler in an HTTPS httptest server and
+// returns the host:port address (suitable for passing to Dial) and the PEM-encoded
+// server certificate (suitable for WithRootCAPem).
+func newHTTPSTestServer(t *testing.T, hdl http.Handler) (addr string, caPEM []byte) {
+	t.Helper()
+	srv := httptest.NewTLSServer(hdl)
+	t.Cleanup(srv.Close)
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	return srv.Listener.Addr().String(), caPEM
+}
+
+// newKMIPHTTPSServer registers an Activate handler and returns an HTTPS test server.
+func newKMIPHTTPSServer(t *testing.T) (addr string, caPEM []byte) {
+	t.Helper()
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+		}))
+	return newHTTPSTestServer(t, kmipserver.NewHTTPHandler(mux))
+}
+
+func TestHTTPTransport_WireFormats(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	for _, tc := range []struct {
+		name string
+		f    kmiphttp.WireFormat
+	}{
+		{"TTLV", kmiphttp.WireTTLV},
+		{"XML", kmiphttp.WireXML},
+		{"JSON", kmiphttp.WireJSON},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := kmipclient.Dial(addr,
+				kmiphttp.WithTransport("/", kmiphttp.WithWireFormat(tc.f)),
+				kmipclient.WithRootCAPem(ca),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = client.Close() })
+
+			require.NotNil(t, client.Version())
+
+			resp, err := client.Activate("uid-42").Exec()
+			require.NoError(t, err)
+			require.Equal(t, "uid-42", resp.UniqueIdentifier)
+		})
+	}
+}
+
+func TestHTTPTransport_DefaultWireIsTTLV(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	resp, err := client.Activate("foo").Exec()
+	require.NoError(t, err)
+	require.Equal(t, "foo", resp.UniqueIdentifier)
+}
+
+func TestHTTPTransport_PathRoutedToServer(t *testing.T) {
+	mux := http.NewServeMux()
+	kmipMux := kmipserver.NewBatchExecutor()
+	kmipMux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+		}))
+	mux.Handle("/kmip", kmipserver.NewHTTPHandler(kmipMux))
+
+	addr, ca := newHTTPSTestServer(t, mux)
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/kmip"),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	resp, err := client.Activate("p").Exec()
+	require.NoError(t, err)
+	require.Equal(t, "p", resp.UniqueIdentifier)
+}
+
+func TestHTTPTransport_NonOKError(t *testing.T) {
+	addr, ca := newHTTPSTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+
+	_, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.Error(t, err)
+	var hErr *kmiphttp.Error
+	require.ErrorAs(t, err, &hErr)
+	require.Equal(t, http.StatusInternalServerError, hErr.StatusCode)
+	require.Contains(t, string(hErr.Body), "boom")
+}
+
+func TestHTTPTransport_ResponseTooLarge(t *testing.T) {
+	// Server returns a response with a deliberately large UID so the response body
+	// exceeds the client's max-message-size while the request body remains small.
+	addr, ca := newHTTPSTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := &kmip.ResponseMessage{
+			Header: kmip.ResponseHeader{
+				ProtocolVersion: kmip.V1_4,
+				BatchCount:      1,
+			},
+			BatchItem: []kmip.ResponseBatchItem{{
+				Operation:    kmip.OperationActivate,
+				ResultStatus: kmip.ResultStatusSuccess,
+				ResponsePayload: &payloads.ActivateResponsePayload{
+					UniqueIdentifier: strings.Repeat("a", 4096),
+				},
+			}},
+		}
+		body := ttlv.MarshalTTLV(resp)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write(body)
+	}))
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+		kmipclient.EnforceVersion(kmip.V1_4),
+		kmipclient.WithMaxMessageSize(512),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.Activate("uid").Exec()
+	require.ErrorIs(t, err, kmipclient.ErrResponseTooLarge)
+}
+
+func TestHTTPTransport_HeaderInjected(t *testing.T) {
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+		}))
+
+	var seen atomic.Value
+	addr, ca := newHTTPSTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen.Store(r.Header.Get("X-Foo"))
+		kmipserver.NewHTTPHandler(mux).ServeHTTP(w, r)
+	}))
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/", kmiphttp.WithHeader("X-Foo", "bar")),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.Activate("h").Exec()
+	require.NoError(t, err)
+	require.Equal(t, "bar", seen.Load())
+}
+
+func TestHTTPTransport_RejectsReservedHeader(t *testing.T) {
+	for _, key := range []string{
+		"Content-Type", "content-type", // canonicalization must be applied
+		"Accept",
+		"Content-Length",
+		"Host",
+		"Transfer-Encoding", "transfer-encoding",
+		"Trailer",
+	} {
+		t.Run(key, func(t *testing.T) {
+			_, err := kmipclient.Dial("127.0.0.1:1",
+				kmiphttp.WithTransport("/", kmiphttp.WithHeader(key, "x")),
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "reserved")
+		})
+	}
+}
+
+type countingRoundTripper struct {
+	inner http.RoundTripper
+	calls atomic.Int64
+}
+
+func (c *countingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.calls.Add(1)
+	return c.inner.RoundTrip(req)
+}
+
+// httpClientWithCA builds an *http.Client that trusts the given PEM CA. Used when
+// passing a custom http.Client through WithClient (which bypasses kmipclient's
+// own TLS plumbing).
+func httpClientWithCA(t *testing.T, caPEM []byte, rt http.RoundTripper) *http.Client {
+	t.Helper()
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM), "appending CA")
+	if base, ok := rt.(*countingRoundTripper); ok {
+		inner := base.inner.(*http.Transport).Clone()
+		inner.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+		base.inner = inner
+		return &http.Client{Transport: base}
+	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+	return &http.Client{Transport: tr}
+}
+
+func TestHTTPTransport_CustomHTTPClient(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	rt := &countingRoundTripper{inner: http.DefaultTransport}
+	hc := httpClientWithCA(t, ca, rt)
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/", kmiphttp.WithClient(hc)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.Activate("a").Exec()
+	require.NoError(t, err)
+	_, err = client.Activate("b").Exec()
+	require.NoError(t, err)
+
+	// 1 DiscoverVersions during Dial + 2 Activate = 3
+	require.GreaterOrEqual(t, rt.calls.Load(), int64(3))
+}
+
+func TestHTTPTransport_CloneSharesPool(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	rt := &countingRoundTripper{inner: http.DefaultTransport}
+	hc := httpClientWithCA(t, ca, rt)
+
+	c1, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/", kmiphttp.WithClient(hc)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c1.Close() })
+
+	c2, err := c1.Clone()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c2.Close() })
+
+	before := rt.calls.Load()
+	_, err = c2.Activate("clone").Exec()
+	require.NoError(t, err)
+	require.Equal(t, before+1, rt.calls.Load(),
+		"clone should reuse the same http.Client (no extra round-trip on Clone)")
+}
+
+func TestHTTPTransport_CloneCloseIndependence(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	c1, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c1.Close() })
+
+	c2, err := c1.Clone()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c2.Close() })
+
+	require.NoError(t, c1.Close())
+
+	resp, err := c2.Activate("clone-survives").Exec()
+	require.NoError(t, err)
+	require.Equal(t, "clone-survives", resp.UniqueIdentifier)
+
+	_, err = c1.Activate("orig-closed").Exec()
+	require.ErrorIs(t, err, net.ErrClosed)
+}
+
+// TestHTTPTransport_RejectsBadPath covers every path-shape rejection in one
+// table. Each case fails at config-validation time (no real connection to
+// 127.0.0.1:1 is ever attempted), so the suite stays cheap.
+func TestHTTPTransport_RejectsBadPath(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		path      string
+		substring string
+	}{
+		{"NoLeadingSlash", "kmip", "must start with"},
+		// Fragments are silently stripped from the request line by net/http;
+		// rejecting at build time prevents that surprise.
+		{"Fragment", "/kmip#frag", "fragment"},
+		// KMIP-over-HTTPS has no query semantics, but a query string would
+		// otherwise ride on every POST.
+		{"QueryString", "/kmip?foo=bar", "query string"},
+		// Caught by buildRequestURL's url.Parse — assert on "control" so the
+		// expectation is pinned to net/url's "invalid control character in URL"
+		// wording rather than any "kmip http:"-prefixed error.
+		{"ControlChar", "/foo\x00bar", "control"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := kmipclient.Dial("127.0.0.1:1",
+				kmiphttp.WithTransport(tc.path),
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.substring)
+		})
+	}
+}
+
+// TestHTTPTransport_AggregatesPathErrors locks in that all three path-shape
+// checks (prefix, fragment, query) run independently, so a single bad path
+// surfaces every problem at once instead of stopping at the first.
+func TestHTTPTransport_AggregatesPathErrors(t *testing.T) {
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmiphttp.WithTransport("bad#frag?q=1"),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must start with")
+	require.Contains(t, err.Error(), "fragment")
+	require.Contains(t, err.Error(), "query string")
+}
+
+// TestHTTPTransport_DoesNotFollowRedirect locks in the documented contract
+// that the default http.Client refuses to follow 3xx responses, surfacing
+// them as a typed [*kmiphttp.Error] with the redirect status code.
+//
+// Implementation note: this test relies on Dial performing protocol version
+// negotiation, which issues a real round-trip and therefore exercises the
+// no-redirect policy. If version negotiation is ever made lazy, this test
+// will need to issue an explicit round-trip after Dial instead.
+func TestHTTPTransport_DoesNotFollowRedirect(t *testing.T) {
+	addr, ca := newHTTPSTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://elsewhere.invalid/")
+		w.WriteHeader(http.StatusFound)
+	}))
+
+	_, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.Error(t, err)
+	var hErr *kmiphttp.Error
+	require.ErrorAs(t, err, &hErr)
+	require.Equal(t, http.StatusFound, hErr.StatusCode)
+}
+
+// TestHTTPTransport_WithClient_PreservesCheckRedirect verifies that when the
+// caller supplies their own *http.Client, the transport does NOT override its
+// CheckRedirect policy — the caller owns redirect handling. We prove this by
+// installing a sentinel CheckRedirect: if the transport had clobbered it with
+// noFollowRedirect, the response would surface as a *kmiphttp.Error instead.
+func TestHTTPTransport_WithClient_PreservesCheckRedirect(t *testing.T) {
+	addr, ca := newHTTPSTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://elsewhere.invalid/")
+		w.WriteHeader(http.StatusFound)
+	}))
+
+	sentinel := errors.New("custom CheckRedirect")
+	hc := httpClientWithCA(t, ca, nil)
+	hc.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return sentinel }
+
+	_, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/", kmiphttp.WithClient(hc)),
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestHTTPTransport_AggregatesConfigErrors: a user with several mistakes
+// (bad path + bad header + reserved header) sees them all at once.
+func TestHTTPTransport_AggregatesConfigErrors(t *testing.T) {
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmiphttp.WithTransport("kmip", // bad path
+			kmiphttp.WithHeader("", "v"),             // empty header key
+			kmiphttp.WithHeader("Content-Type", "x"), // reserved header
+		),
+	)
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "must start with")
+	require.Contains(t, msg, "empty header key")
+	require.Contains(t, msg, "reserved")
+}
+
+func TestHTTPTransport_RejectsEmptyHeaderKey(t *testing.T) {
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmiphttp.WithTransport("/", kmiphttp.WithHeader("", "v")),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty header key")
+}
+
+func TestHTTPTransport_RejectedByDialCluster(t *testing.T) {
+	_, err := kmipclient.DialCluster([]string{"127.0.0.1:1", "127.0.0.1:2"},
+		kmiphttp.WithTransport("/"),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DialCluster")
+}
+
+func TestHTTPTransport_RejectsAddrWithScheme(t *testing.T) {
+	_, err := kmipclient.Dial("https://127.0.0.1:1",
+		kmiphttp.WithTransport("/"),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host:port")
+}
+
+func TestHTTPTransport_RejectsMalformedAddr(t *testing.T) {
+	_, err := kmipclient.Dial("not-an-address",
+		kmiphttp.WithTransport("/"),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid addr")
+}
+
+// TestHTTPTransport_RejectsHTTPClientWithTLSOptions ensures every standard TLS
+// option triggers the up-front rejection when combined with WithClient,
+// matching the documented contract.
+func TestHTTPTransport_RejectsHTTPClientWithTLSOptions(t *testing.T) {
+	pemBlock := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("fake")})
+
+	for name, tlsOpt := range map[string]kmipclient.Option{
+		"WithRootCAPem":      kmipclient.WithRootCAPem(pemBlock),
+		"WithServerName":     kmipclient.WithServerName("kms.example.com"),
+		"WithTlsConfig":      kmipclient.WithTlsConfig(&tls.Config{MinVersion: tls.VersionTLS12}),
+		"WithTlsCipherSuite": kmipclient.WithTlsCipherSuites(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := kmipclient.Dial("127.0.0.1:1",
+				kmiphttp.WithTransport("/", kmiphttp.WithClient(&http.Client{})),
+				tlsOpt,
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "mutually exclusive")
+		})
+	}
+}
+
+// TestHTTPTransport_RejectsHTTPClientWithDialer ensures that combining
+// WithClient and WithDialerUnsafe is rejected up-front: the dialer would
+// silently never be invoked because the supplied http.Client is used as-is, and
+// failing fast is preferable to that surprise.
+func TestHTTPTransport_RejectsHTTPClientWithDialer(t *testing.T) {
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmiphttp.WithTransport("/", kmiphttp.WithClient(&http.Client{})),
+		kmipclient.WithDialerUnsafe(func(context.Context, string) (net.Conn, error) {
+			return nil, errors.New("should not be called")
+		}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestHTTPTransport_MiddlewareRuns(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	var ran atomic.Bool
+	mw := kmipclient.Middleware(func(next kmipclient.Next, ctx context.Context, req *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
+		ran.Store(true)
+		return next(ctx, req)
+	})
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+		kmipclient.WithMiddlewares(mw),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.Activate("m").Exec()
+	require.NoError(t, err)
+	require.True(t, ran.Load())
+}
+
+// roundTripperFunc adapts a plain function to http.RoundTripper, so tests can
+// install a wrapper inline without declaring a struct each time.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestHTTPTransport_RoundTripperWraps(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	var seenURL atomic.Value
+	var calls atomic.Int64
+	wrap := func(next http.RoundTripper) http.RoundTripper {
+		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			seenURL.Store(req.URL.String())
+			return next.RoundTrip(req)
+		})
+	}
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/", kmiphttp.WrapRoundTripper(wrap)),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.Activate("rt").Exec()
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, calls.Load(), int64(1), "wrapper must observe the request")
+	require.Equal(t, "https://"+addr+"/", seenURL.Load())
+}
+
+func TestHTTPTransport_RoundTripperOrder(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	var mu sync.Mutex
+	var order []string
+	record := func(name string) func(http.RoundTripper) http.RoundTripper {
+		return func(next http.RoundTripper) http.RoundTripper {
+			return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				mu.Lock()
+				order = append(order, name+"-in")
+				mu.Unlock()
+				resp, err := next.RoundTrip(req)
+				mu.Lock()
+				order = append(order, name+"-out")
+				mu.Unlock()
+				return resp, err
+			})
+		}
+	}
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/",
+			kmiphttp.WrapRoundTripper(record("a")),
+			kmiphttp.WrapRoundTripper(record("b")),
+		),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Dial performs a protocol-version negotiation roundtrip, which the
+	// wrappers see; reset so the assertion covers exactly the Activate call.
+	mu.Lock()
+	order = order[:0]
+	mu.Unlock()
+
+	_, err = client.Activate("ord").Exec()
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"a-in", "b-in", "b-out", "a-out"}, order,
+		"first registered wrapper must be outermost")
+}
+
+func TestHTTPTransport_RejectsRoundTripperWithHTTPClient(t *testing.T) {
+	wrap := func(next http.RoundTripper) http.RoundTripper { return next }
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmiphttp.WithTransport("/",
+			kmiphttp.WithClient(&http.Client{}),
+			kmiphttp.WrapRoundTripper(wrap),
+		),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestHTTPTransport_RejectsNilRoundTripper(t *testing.T) {
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmiphttp.WithTransport("/", kmiphttp.WrapRoundTripper(nil)),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil RoundTripper")
+}
+
+// TestHTTPTransport_RejectsRoundTripperReturningNil also checks that the error
+// names the offending wrapper by index, so multi-wrapper setups are diagnosable.
+func TestHTTPTransport_RejectsRoundTripperReturningNil(t *testing.T) {
+	identity := func(next http.RoundTripper) http.RoundTripper { return next }
+	returnsNil := func(http.RoundTripper) http.RoundTripper { return nil }
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmiphttp.WithTransport("/",
+			kmiphttp.WrapRoundTripper(identity),
+			kmiphttp.WrapRoundTripper(returnsNil),
+		),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrapper #1 returned nil")
+}
+
+// TestHTTPTransport_ServerCertVerify ensures TLS options actually flow into the
+// HTTP transport: pointing at an HTTPS server without supplying the CA must fail
+// verification.
+func TestHTTPTransport_ServerCertVerify(t *testing.T) {
+	addr, _ := newKMIPHTTPSServer(t)
+
+	_, err := kmipclient.Dial(addr, kmiphttp.WithTransport("/"))
+	require.Error(t, err)
+
+	var ce *tls.CertificateVerificationError
+	var ue x509.UnknownAuthorityError
+	require.True(t, errors.As(err, &ce) || errors.As(err, &ue),
+		"expected a TLS verification error, got %T: %v", err, err)
+}
+
+// TestHTTPTransport_WithDialerUnsafe ensures that a custom DialerFunc is honored:
+// the http transport dispatches its TLS dial through the user-supplied dialer
+// instead of the default TLS plumbing.
+func TestHTTPTransport_WithDialerUnsafe(t *testing.T) {
+	addr, ca := newKMIPHTTPSServer(t)
+
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(ca))
+	tlsCfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+
+	var dialed atomic.Int64
+	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
+		dialed.Add(1)
+		td := tls.Dialer{Config: tlsCfg}
+		return td.DialContext(ctx, "tcp", addr)
+	}
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithDialerUnsafe(dialer),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.Activate("dialer").Exec()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, dialed.Load(), int64(1),
+		"WithDialerUnsafe must be invoked by the HTTP transport")
+}
+
+// TestHTTPTransport_CloseRejectsNewRoundTrip locks in the contract that Close
+// causes subsequent RoundTrip calls to return net.ErrClosed without reaching
+// the network.
+func TestHTTPTransport_CloseRejectsNewRoundTrip(t *testing.T) {
+	var hits atomic.Int64
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			hits.Add(1)
+			return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+		}))
+	addr, ca := newHTTPSTestServer(t, kmipserver.NewHTTPHandler(mux))
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, client.Close())
+
+	beforeHits := hits.Load()
+	_, err = client.Activate("after-close").Exec()
+	require.ErrorIs(t, err, net.ErrClosed)
+	require.Equal(t, beforeHits, hits.Load(),
+		"RoundTrip after Close must short-circuit before reaching the server")
+
+	// Idempotent: a second Close must not panic or change behavior.
+	require.NoError(t, client.Close())
+}
+
+// TestHTTPTransport_ConcurrentRoundTrip exercises N parallel RoundTrips against
+// the same client to verify the documented "safe for concurrent use" contract.
+// The shared http.Client provides the synchronization; the transport must not
+// add external locking that would serialize requests.
+func TestHTTPTransport_ConcurrentRoundTrip(t *testing.T) {
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+		}))
+	addr, ca := newHTTPSTestServer(t, kmipserver.NewHTTPHandler(mux))
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	const goroutines = 16
+	const perGoroutine = 8
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines*perGoroutine)
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range perGoroutine {
+				uid := strconv.Itoa(g*perGoroutine + i)
+				resp, err := client.Activate(uid).Exec()
+				if err != nil {
+					errs <- err
+					return
+				}
+				if resp.UniqueIdentifier != uid {
+					errs <- errors.New("uid mismatch: got " + resp.UniqueIdentifier + " want " + uid)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent roundtrip: %v", err)
+	}
+}
+
+// TestHTTPTransport_ContextCancelMidRequest ensures that cancelling the request
+// context unblocks an in-flight RoundTrip on the client side. Note that
+// HTTP/1.1 does not reliably propagate client cancellation to the server's
+// r.Context(); the test therefore releases the handler explicitly once the
+// client side has been verified, so cleanup does not block on the handler.
+func TestHTTPTransport_ContextCancelMidRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	addr, ca := newHTTPSTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	client, err := kmipclient.Dial(addr,
+		kmiphttp.WithTransport("/"),
+		kmipclient.WithRootCAPem(ca),
+		// Skip DiscoverVersions so Dial itself doesn't hit the slow handler.
+		kmipclient.EnforceVersion(kmip.V1_4),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.Close()
+		// Drain the handler before httptest.Server.Close runs; client cancel
+		// does not necessarily propagate to r.Context() over HTTP/1.1, so
+		// without this the cleanup blocks for 5s waiting on an active conn.
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Activate("cancel-me").ExecContext(ctx)
+		done <- err
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "expected an error after cancel")
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RoundTrip did not return within 2s after context cancel")
+	}
+
+	// Release the handler so httptest.Server.Close doesn't have to wait on it.
+	close(release)
+}

--- a/kmipclient/transport.go
+++ b/kmipclient/transport.go
@@ -1,0 +1,225 @@
+package kmipclient
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/ovh/kmip-go"
+	"github.com/ovh/kmip-go/ttlv"
+)
+
+const streamReconnectAttempts = 3
+
+// ErrResponseTooLarge is returned by both transports when the server's
+// response exceeds the configured WithMaxMessageSize limit. Use errors.Is
+// to detect it.
+var ErrResponseTooLarge = errors.New("kmip: response exceeds max message size")
+
+// Transport sends a KMIP request and returns the response. Implementations own
+// their own (re)connection lifecycle and must be safe for concurrent use; the
+// Client does not serialize RoundTrip externally.
+//
+// Clone returns an independent transport configured the same way as the
+// receiver. The new transport has its own connection state and lifecycle, so
+// closing the receiver does not affect the clone (and vice versa). Clone is
+// valid on a closed transport.
+type Transport interface {
+	RoundTrip(ctx context.Context, msg *kmip.RequestMessage) (*kmip.ResponseMessage, error)
+	Clone(ctx context.Context) (Transport, error)
+	Close() error
+}
+
+// DialInfo carries the dial-time information a [TransportBuilder] needs to
+// construct a [Transport].
+//
+// When adding a new TLS-affecting [Option], update [opts.hasTLSOptions] so
+// TLSConfigured keeps reflecting it, and ensure [buildTransport] populates any
+// new DialInfo field that exposes it to builders.
+type DialInfo struct {
+	// Addr is the bare host:port passed to Dial.
+	Addr string
+	// TLSConfig is the resolved *tls.Config built from the standard kmipclient
+	// TLS options. Nil when Dialer is set, since a custom dialer takes full
+	// responsibility for negotiating TLS itself. Treat as read-only — the
+	// kmipclient runtime does not defensively copy it, so a builder mutating
+	// it would race with any other transport sharing the same config.
+	TLSConfig *tls.Config
+	// Dialer is the custom dialer set via WithDialerUnsafe, or nil if none.
+	Dialer DialerFunc
+	// MaxMessageSize is the configured max response size in bytes (see
+	// [WithMaxMessageSize]). Never zero when reaching a TransportBuilder: Dial
+	// normalizes a zero/unset user value to [ttlv.DefaultMaxMessageSize] (1 MB)
+	// before constructing DialInfo. A negative value disables the cap and is
+	// passed through to the transport.
+	MaxMessageSize int
+	// TLSConfigured reports whether any of the standard kmipclient TLS options
+	// were set. Used by transports that accept a fully-custom client to enforce
+	// mutual exclusivity at Dial time.
+	//
+	// Note the asymmetry with TLSConfig: when Dialer is set, TLSConfig is
+	// nil'd (the dialer takes over) but TLSConfigured still reflects whatever
+	// TLS options the user supplied. A transport author deciding whether to
+	// reject "TLS option + custom client" must consult TLSConfigured, not
+	// TLSConfig != nil.
+	TLSConfigured bool
+}
+
+// TransportBuilder constructs a [Transport] from the dial-time info. It is
+// invoked once during [DialContext] when [WithTransportBuilder] is set.
+type TransportBuilder func(ctx context.Context, info DialInfo) (Transport, error)
+
+// streamTransport is the TTLV-over-TCP/TLS transport. The wire protocol is
+// single-flight, so all access is serialized via mu.
+//
+// State machine for s.conn (under s.mu):
+//   - non-nil, healthy: normal operation.
+//   - nil: previous RoundTrip detected a poisoned conn (ErrMessageTooLarge) and
+//     a reconnect attempt failed; the next RoundTrip will lazily redial before
+//     sending. Distinguishing nil from "user closed" lets us avoid surfacing a
+//     stale ErrMessageTooLarge from conn.ctx as ErrResponseTooLarge on a fresh
+//     request that wasn't even oversized.
+//   - non-nil, closed: user called Close(); subsequent RoundTrips return
+//     net.ErrClosed without dialing.
+type streamTransport struct {
+	dial    func(ctx context.Context) (net.Conn, error)
+	maxSize int
+
+	mu     sync.Mutex
+	conn   *conn
+	closed bool
+}
+
+// reconnect dials a fresh conn and replaces s.conn. On success, the old conn
+// is closed after the new dial returns. On dial failure, the old conn is also
+// closed and s.conn is set to nil so the next RoundTrip lazily redials rather
+// than re-using a poisoned conn whose cached terminate cause would mislead
+// error reporting. Must be called with s.mu held.
+func (s *streamTransport) reconnect(ctx context.Context) error {
+	nc, err := s.dial(ctx)
+	if err != nil {
+		// Drop the old conn so the next RoundTrip starts from scratch instead
+		// of inheriting any cached error state.
+		if s.conn != nil {
+			_ = s.conn.Close()
+			s.conn = nil
+		}
+		return err
+	}
+	if s.conn != nil {
+		_ = s.conn.Close()
+	}
+	s.conn = newConn(nc, s.maxSize)
+	return nil
+}
+
+func (s *streamTransport) RoundTrip(ctx context.Context, msg *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil, net.ErrClosed
+	}
+	// Lazy redial when a previous run left us without a usable conn (failed
+	// reconnect after ErrMessageTooLarge or io.EOF/io.ErrClosedPipe).
+	if s.conn == nil {
+		if err := s.reconnect(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	retry := streamReconnectAttempts
+	for {
+		resp, err := s.conn.roundtrip(ctx, msg)
+		if err == nil {
+			return resp, nil
+		}
+		// Oversized responses poison the conn (the readloop terminates the
+		// stream on the size trip), and retrying in-loop wouldn't change the
+		// response size. Eagerly reconnect so the next RoundTrip doesn't see
+		// the cached terminate cause; on reconnect failure, s.conn is left
+		// nil and the next call lazily redials.
+		if errors.Is(err, ttlv.ErrMessageTooLarge) {
+			rtErr := fmt.Errorf("%w: %w", ErrResponseTooLarge, err)
+			if rerr := s.reconnect(ctx); rerr != nil {
+				return nil, errors.Join(rtErr, rerr)
+			}
+			return nil, rtErr
+		}
+		if retry <= 0 || (!errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe)) {
+			return nil, err
+		}
+		if rerr := s.reconnect(ctx); rerr != nil {
+			return nil, errors.Join(err, rerr)
+		}
+		retry--
+	}
+}
+
+// Close blocks until any in-flight RoundTrip releases the mutex; cancel its
+// context to abort sooner. Close is idempotent: subsequent calls return nil.
+// After Close, RoundTrip returns net.ErrClosed without dialing.
+func (s *streamTransport) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if s.conn == nil {
+		return nil
+	}
+	return s.conn.Close()
+}
+
+// Clone dials a fresh stream transport reusing the receiver's dial closure
+// and size cap. The new transport has its own conn and mutex; the receiver's
+// state (including closed-ness) is not consulted.
+func (s *streamTransport) Clone(ctx context.Context) (Transport, error) {
+	return newStreamTransport(ctx, s.dial, s.maxSize)
+}
+
+func newStreamTransport(ctx context.Context, dial func(ctx context.Context) (net.Conn, error), maxSize int) (Transport, error) {
+	s := &streamTransport{dial: dial, maxSize: maxSize}
+	if err := s.reconnect(ctx); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func buildTransport(ctx context.Context, o *opts, tlsCfg *tls.Config, addr string) (Transport, error) {
+	if o.transportBuilder != nil {
+		// A custom dialer takes full responsibility for TLS, so the
+		// kmipclient-built config would be unused — drop it.
+		ctxTLS := tlsCfg
+		if o.dialer != nil {
+			ctxTLS = nil
+		}
+		return o.transportBuilder(ctx, DialInfo{
+			Addr:           addr,
+			TLSConfig:      ctxTLS,
+			Dialer:         o.dialer,
+			MaxMessageSize: o.maxMessageSize,
+			TLSConfigured:  o.hasTLSOptions(),
+		})
+	}
+	pa := perAddrStreamDialer(o.dialer, tlsCfg)
+	dial := func(ctx context.Context) (net.Conn, error) { return pa(ctx, addr) }
+	return newStreamTransport(ctx, dial, o.maxMessageSize)
+}
+
+// perAddrStreamDialer falls back to a standard tls.Dialer when no DialerFunc
+// is set; with a DialerFunc, the caller is responsible for negotiating TLS.
+func perAddrStreamDialer(d DialerFunc, tlsCfg *tls.Config) func(ctx context.Context, addr string) (net.Conn, error) {
+	if d != nil {
+		return d
+	}
+	td := &tls.Dialer{Config: tlsCfg}
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		return td.DialContext(ctx, "tcp", addr)
+	}
+}

--- a/kmipclient/transport_test.go
+++ b/kmipclient/transport_test.go
@@ -1,0 +1,426 @@
+package kmipclient_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ovh/kmip-go"
+	"github.com/ovh/kmip-go/kmipclient"
+	"github.com/ovh/kmip-go/kmipserver"
+	"github.com/ovh/kmip-go/kmiptest"
+	"github.com/ovh/kmip-go/payloads"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamTransport_ResponseTooLarge confirms the stream transport surfaces
+// oversized responses as ErrResponseTooLarge, matching the HTTP transport.
+func TestStreamTransport_ResponseTooLarge(t *testing.T) {
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			// Pad the UID so the encoded response exceeds the client's cap.
+			return &payloads.ActivateResponsePayload{
+				UniqueIdentifier: strings.Repeat("a", 4096),
+			}, nil
+		}))
+
+	addr, ca := kmiptest.NewServer(t, mux)
+	client, err := kmipclient.Dial(addr,
+		kmipclient.WithRootCAPem([]byte(ca)),
+		// EnforceVersion skips DiscoverVersions, whose response size is
+		// independent of the test and could exceed the cap on its own.
+		kmipclient.EnforceVersion(kmip.V1_4),
+		kmipclient.WithMaxMessageSize(512),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.Activate("uid").Exec()
+	require.ErrorIs(t, err, kmipclient.ErrResponseTooLarge)
+}
+
+// TestStreamTransport_CloseBlocksDuringInFlight pins down the documented
+// behavior of streamTransport.Close: it blocks until the in-flight RoundTrip
+// releases the per-transport mutex, and the way to abort sooner is to cancel
+// the RoundTrip context.
+func TestStreamTransport_CloseBlocksDuringInFlight(t *testing.T) {
+	started := make(chan struct{})
+
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(ctx context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}))
+
+	addr, ca := kmiptest.NewServer(t, mux)
+	client, err := kmipclient.Dial(addr, kmipclient.WithRootCAPem([]byte(ca)))
+	require.NoError(t, err)
+
+	rtCtx, rtCancel := context.WithCancel(context.Background())
+	defer rtCancel()
+
+	rtDone := make(chan struct{})
+	go func() {
+		_, _ = client.Activate("inflight").ExecContext(rtCtx)
+		close(rtDone)
+	}()
+
+	// Wait for the handler to start, proving the RoundTrip is in flight and
+	// holds the streamTransport mutex.
+	<-started
+
+	closeReturned := make(chan error, 1)
+	var closeStarted atomic.Bool
+	go func() {
+		closeStarted.Store(true)
+		closeReturned <- client.Close()
+	}()
+
+	// Spin until the Close goroutine has at least entered Close.
+	require.Eventually(t, closeStarted.Load, time.Second, time.Millisecond)
+
+	// Close must remain blocked on the in-flight RoundTrip's mutex.
+	select {
+	case err := <-closeReturned:
+		t.Fatalf("Close returned while RoundTrip in flight: err=%v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Cancelling the RoundTrip context releases the mutex; Close can now finish.
+	rtCancel()
+	<-rtDone
+
+	select {
+	case err := <-closeReturned:
+		// Close may surface the underlying read error from the cancelled
+		// RoundTrip; the contract we care about is that it eventually returns.
+		_ = err
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return after RoundTrip completed")
+	}
+}
+
+// TestStreamTransport_DoubleClose pins down Close idempotency: a second Close
+// must not panic or error, and a RoundTrip after Close must return
+// net.ErrClosed without dialing.
+func TestStreamTransport_DoubleClose(t *testing.T) {
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+		}))
+
+	addr, ca := kmiptest.NewServer(t, mux)
+	client, err := kmipclient.Dial(addr, kmipclient.WithRootCAPem([]byte(ca)))
+	require.NoError(t, err)
+
+	require.NoError(t, client.Close())
+	require.NoError(t, client.Close(), "second Close must be idempotent")
+
+	_, err = client.Activate("after-close").Exec()
+	require.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestStreamTransport_CloneAfterClose(t *testing.T) {
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+		}))
+
+	addr, ca := kmiptest.NewServer(t, mux)
+	client, err := kmipclient.Dial(addr, kmipclient.WithRootCAPem([]byte(ca)))
+	require.NoError(t, err)
+
+	require.NoError(t, client.Close())
+
+	clone, err := client.Clone()
+	require.NoError(t, err, "Clone must succeed after Close")
+	t.Cleanup(func() { _ = clone.Close() })
+
+	resp, err := clone.Activate("after-close-clone").Exec()
+	require.NoError(t, err)
+	require.Equal(t, "after-close-clone", resp.UniqueIdentifier)
+
+	_, err = client.Activate("still-closed").Exec()
+	require.ErrorIs(t, err, net.ErrClosed)
+}
+
+// TestStreamTransport_RecoversAfterResponseTooLarge verifies that a RoundTrip
+// returning ErrResponseTooLarge leaves the transport in a usable state: a
+// subsequent request that fits within the cap must succeed instead of
+// inheriting the previous run's cached terminate cause.
+func TestStreamTransport_RecoversAfterResponseTooLarge(t *testing.T) {
+	var big atomic.Bool
+	mux := kmipserver.NewBatchExecutor()
+	mux.Route(kmip.OperationActivate, kmipserver.HandleFunc(
+		func(_ context.Context, req *payloads.ActivateRequestPayload) (*payloads.ActivateResponsePayload, error) {
+			if big.Load() {
+				return &payloads.ActivateResponsePayload{
+					UniqueIdentifier: strings.Repeat("a", 4096),
+				}, nil
+			}
+			return &payloads.ActivateResponsePayload{UniqueIdentifier: req.UniqueIdentifier}, nil
+		}))
+
+	addr, ca := kmiptest.NewServer(t, mux)
+	client, err := kmipclient.Dial(addr,
+		kmipclient.WithRootCAPem([]byte(ca)),
+		kmipclient.EnforceVersion(kmip.V1_4),
+		kmipclient.WithMaxMessageSize(512),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// First call trips the cap.
+	big.Store(true)
+	_, err = client.Activate("uid").Exec()
+	require.ErrorIs(t, err, kmipclient.ErrResponseTooLarge)
+
+	// Second call with a small response must succeed — not surface a cached
+	// ErrResponseTooLarge from the poisoned previous conn.
+	big.Store(false)
+	resp, err := client.Activate("ok").Exec()
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp.UniqueIdentifier)
+	require.False(t, errors.Is(err, kmipclient.ErrResponseTooLarge))
+}
+
+func TestWithTransportBuilder_NilRejected(t *testing.T) {
+	_, err := kmipclient.Dial("127.0.0.1:1", kmipclient.WithTransportBuilder(nil))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil TransportBuilder")
+}
+
+// TestDialContext_AggregatesOptionErrors: a caller with multiple bad options
+// sees them all at once via errors.Join instead of fixing one per Dial.
+func TestDialContext_AggregatesOptionErrors(t *testing.T) {
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmipclient.WithRootCAFile("/__kmipclient_test/__missing_a"),
+		kmipclient.WithRootCAFile("/__kmipclient_test/__missing_b"),
+		kmipclient.WithTransportBuilder(nil),
+	)
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "__missing_a")
+	require.Contains(t, msg, "__missing_b")
+	require.Contains(t, msg, "nil TransportBuilder")
+}
+
+func TestDialClusterContext_AggregatesOptionErrors(t *testing.T) {
+	_, err := kmipclient.DialCluster([]string{"127.0.0.1:1", "127.0.0.1:2"},
+		kmipclient.WithRootCAFile("/__kmipclient_test/__missing_a"),
+		kmipclient.WithRootCAFile("/__kmipclient_test/__missing_b"),
+	)
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "__missing_a")
+	require.Contains(t, msg, "__missing_b")
+}
+
+// TestWithTransportBuilder_ErrorPropagates: builder errors surface verbatim
+// from Dial — sub-packages rely on this to defer validation to dial time.
+func TestWithTransportBuilder_ErrorPropagates(t *testing.T) {
+	sentinel := errors.New("custom transport refused to build")
+	_, err := kmipclient.Dial("127.0.0.1:1",
+		kmipclient.WithTransportBuilder(func(context.Context, kmipclient.DialInfo) (kmipclient.Transport, error) {
+			return nil, sentinel
+		}),
+	)
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestWithTransportBuilder_ReceivesContext pins the DialInfo fields builder
+// authors depend on — if any stops being filled in, custom transports silently
+// break.
+func TestWithTransportBuilder_ReceivesContext(t *testing.T) {
+	var captured kmipclient.DialInfo
+	sentinel := errors.New("captured")
+	_, err := kmipclient.Dial("kms.example.com:5696",
+		kmipclient.WithMaxMessageSize(1234),
+		kmipclient.WithRootCAPem([]byte("---not a real ca---")),
+		kmipclient.WithTransportBuilder(func(_ context.Context, info kmipclient.DialInfo) (kmipclient.Transport, error) {
+			captured = info
+			return nil, sentinel
+		}),
+	)
+	require.ErrorIs(t, err, sentinel)
+	require.Equal(t, "kms.example.com:5696", captured.Addr)
+	require.Equal(t, 1234, captured.MaxMessageSize)
+	require.True(t, captured.TLSConfigured, "TLSConfigured must be true when a TLS option was set")
+	require.NotNil(t, captured.TLSConfig, "TLSConfig must be populated when no custom dialer is set")
+}
+
+// TestWithTransportBuilder_RejectedByDialCluster: any custom transport — not
+// just the kmiphttp adapter — must be rejected by DialCluster.
+func TestWithTransportBuilder_RejectedByDialCluster(t *testing.T) {
+	builderInvoked := false
+	_, err := kmipclient.DialCluster([]string{"127.0.0.1:1", "127.0.0.1:2"},
+		kmipclient.WithTransportBuilder(func(context.Context, kmipclient.DialInfo) (kmipclient.Transport, error) {
+			builderInvoked = true
+			return nil, errors.New("builder must not be invoked")
+		}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DialCluster")
+	require.False(t, builderInvoked, "DialCluster must reject the option without invoking the builder")
+}
+
+// TestDialInfo_TLSConfiguredCoversAllSetters guards the invariant on
+// opts.hasTLSOptions: every standard TLS setter must trip TLSConfigured, or
+// transports gating on it (e.g. kmiphttp.WithClient mutual-exclusivity)
+// silently miss the new option. One case per field consulted by hasTLSOptions
+// — setters that share a field don't all need their own row. Slice (not map)
+// so a missing entry shows up as a deterministic gap in code review rather
+// than as a nondeterministic CI flake.
+func TestDialInfo_TLSConfiguredCoversAllSetters(t *testing.T) {
+	cases := []struct {
+		name string
+		opt  kmipclient.Option
+	}{
+		{"WithTlsConfig", kmipclient.WithTlsConfig(&tls.Config{MinVersion: tls.VersionTLS12})},
+		{"WithRootCAPem", kmipclient.WithRootCAPem([]byte("---not a real ca---"))},
+		{"WithClientCert", kmipclient.WithClientCert(tls.Certificate{})},
+		{"WithServerName", kmipclient.WithServerName("kms.example.com")},
+		{"WithTlsCipherSuites", kmipclient.WithTlsCipherSuites(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured kmipclient.DialInfo
+			sentinel := errors.New("captured")
+			_, err := kmipclient.Dial("kms.example.com:5696",
+				tc.opt,
+				kmipclient.WithTransportBuilder(func(_ context.Context, info kmipclient.DialInfo) (kmipclient.Transport, error) {
+					captured = info
+					return nil, sentinel
+				}),
+			)
+			require.ErrorIs(t, err, sentinel)
+			require.True(t, captured.TLSConfigured, "%s must trip TLSConfigured", tc.name)
+		})
+	}
+}
+
+// recordingTransport is a fake Transport whose RoundTrip returns a canned
+// response and records every call.
+type recordingTransport struct {
+	mu       sync.Mutex
+	calls    int
+	closed   bool
+	response func(*kmip.RequestMessage) (*kmip.ResponseMessage, error)
+}
+
+func (r *recordingTransport) RoundTrip(_ context.Context, msg *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	return r.response(msg)
+}
+
+func (r *recordingTransport) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closed = true
+	return nil
+}
+
+// Clone returns an independent fake so a future test using Client.Clone can't
+// accidentally depend on shared state (e.g. Close affecting both transports).
+// The response closure is shared by design — it's the caller's canned behavior.
+func (r *recordingTransport) Clone(context.Context) (kmipclient.Transport, error) {
+	return &recordingTransport{response: r.response}, nil
+}
+
+// TestWithTransportBuilder_Wires: a builder-supplied Transport is actually
+// wired into the Client — RoundTrip flows through it and Close delegates back.
+// End-to-end coverage of the bare kmipclient.WithTransportBuilder contract,
+// without going through the kmiphttp sub-package.
+func TestWithTransportBuilder_Wires(t *testing.T) {
+	rt := &recordingTransport{
+		response: func(req *kmip.RequestMessage) (*kmip.ResponseMessage, error) {
+			switch p := req.BatchItem[0].RequestPayload.(type) {
+			case *payloads.DiscoverVersionsRequestPayload:
+				return &kmip.ResponseMessage{
+					Header: kmip.ResponseHeader{
+						ProtocolVersion: kmip.V1_4,
+						BatchCount:      1,
+					},
+					BatchItem: []kmip.ResponseBatchItem{{
+						Operation:    kmip.OperationDiscoverVersions,
+						ResultStatus: kmip.ResultStatusSuccess,
+						ResponsePayload: &payloads.DiscoverVersionsResponsePayload{
+							ProtocolVersion: []kmip.ProtocolVersion{kmip.V1_4},
+						},
+					}},
+				}, nil
+			case *payloads.ActivateRequestPayload:
+				return &kmip.ResponseMessage{
+					Header: kmip.ResponseHeader{
+						ProtocolVersion: kmip.V1_4,
+						BatchCount:      1,
+					},
+					BatchItem: []kmip.ResponseBatchItem{{
+						Operation:    kmip.OperationActivate,
+						ResultStatus: kmip.ResultStatusSuccess,
+						ResponsePayload: &payloads.ActivateResponsePayload{
+							UniqueIdentifier: p.UniqueIdentifier,
+						},
+					}},
+				}, nil
+			default:
+				return nil, fmt.Errorf("recordingTransport: unexpected payload %T", p)
+			}
+		},
+	}
+
+	client, err := kmipclient.Dial("test:1",
+		kmipclient.WithTransportBuilder(func(context.Context, kmipclient.DialInfo) (kmipclient.Transport, error) {
+			return rt, nil
+		}),
+	)
+	require.NoError(t, err)
+	rt.mu.Lock()
+	require.GreaterOrEqual(t, rt.calls, 1, "DiscoverVersions must flow through the builder-supplied transport")
+	rt.mu.Unlock()
+
+	resp, err := client.Activate("uid").Exec()
+	require.NoError(t, err)
+	require.Equal(t, "uid", resp.UniqueIdentifier)
+
+	require.NoError(t, client.Close())
+	rt.mu.Lock()
+	require.True(t, rt.closed, "Client.Close must delegate to the builder-supplied transport")
+	rt.mu.Unlock()
+}
+
+// TestDialInfo_TLSConfigNilWhenDialerSet: when a custom dialer is configured
+// it takes full responsibility for TLS, so TLSConfig must be dropped from the
+// info — even if the caller also set a TLS option.
+func TestDialInfo_TLSConfigNilWhenDialerSet(t *testing.T) {
+	var captured kmipclient.DialInfo
+	sentinel := errors.New("captured")
+	_, err := kmipclient.Dial("kms.example.com:5696",
+		kmipclient.WithServerName("kms.example.com"),
+		kmipclient.WithDialerUnsafe(func(context.Context, string) (net.Conn, error) {
+			return nil, errors.New("not invoked")
+		}),
+		kmipclient.WithTransportBuilder(func(_ context.Context, info kmipclient.DialInfo) (kmipclient.Transport, error) {
+			captured = info
+			return nil, sentinel
+		}),
+	)
+	require.ErrorIs(t, err, sentinel)
+	require.NotNil(t, captured.Dialer, "Dialer must be threaded through")
+	require.Nil(t, captured.TLSConfig, "TLSConfig must be nil when Dialer is set")
+}

--- a/kmipserver/conn.go
+++ b/kmipserver/conn.go
@@ -120,7 +120,7 @@ func (c *conn) checkAvailable() error {
 // or errors to the rx channel. If a terminal error occurs or the context is done, it terminates
 // the loop and closes the rx channel. This function is intended to run as a goroutine.
 func (c *conn) readloop() {
-	defer c.logger.Debug("Exittig readloop")
+	defer c.logger.Debug("Exiting readloop")
 	defer close(c.rx)
 	for !c.closed.Load() {
 		msg := recvMsg{}
@@ -158,7 +158,7 @@ func (c *conn) readloop() {
 // the connection on failure. The loop exits when the connection is closed or the context is done.
 // Any remaining messages in the tx channel are not drained when the context is canceled (see TODO).
 func (c *conn) writeloop() {
-	defer c.logger.Debug("Exittig writeloop")
+	defer c.logger.Debug("Exiting writeloop")
 	tx := c.tx.Load().(chan txMsg)
 	for !c.closed.Load() {
 		select {

--- a/kmipserver/server.go
+++ b/kmipserver/server.go
@@ -151,7 +151,6 @@ func (srv *Server) Serve() error {
 			if errors.Is(err, net.ErrClosed) {
 				return ErrShutdown
 			}
-			//TODO: Return a shutdown error if shutdown has been requested
 			return err
 		}
 		srv.wg.Add(1)

--- a/kmipserver/server_test.go
+++ b/kmipserver/server_test.go
@@ -164,7 +164,7 @@ func TestServerWithMaxMessageSize(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, resp.BatchItem, 1)
 		require.Equal(t, kmip.ResultStatusOperationFailed, resp.BatchItem[0].ResultStatus)
-		require.Contains(t, resp.BatchItem[0].ResultMessage, "too big")
+		require.Contains(t, resp.BatchItem[0].ResultMessage, "exceeds max size")
 	})
 
 	t.Run("accepts request within max size", func(t *testing.T) {

--- a/payloads/locate.go
+++ b/payloads/locate.go
@@ -63,12 +63,12 @@ type LocateRequestPayload struct {
 	// An Integer object that indicates the maximum number of object identifiers the server MAY return.
 	MaximumItems int32 `ttlv:",omitempty"`
 	// An Integer object that indicates the number of object identifiers to skip that satisfy the identification criteria specified in the request.
-	OffsetItems int32 `ttlv:",omitempty,version=1.3.."`
+	OffsetItems int32 `ttlv:",omitempty,version=v1.3.."`
 	// An Integer object (used as a bit mask) that indicates whether only on-line objects, only archived objects,
 	// or both on-line and archived objects are to be searched. If omitted, then on-line only is assumed.
 	StorageStatusMask kmip.StorageStatusMask `ttlv:",omitempty"`
 	// An Enumeration object that indicates the object group member type.
-	ObjectGroupMember kmip.ObjectGroupMember `ttlv:",omitempty,version=1.1.."`
+	ObjectGroupMember kmip.ObjectGroupMember `ttlv:",omitempty,version=v1.1.."`
 	// Specifies an attribute and its value(s) that are REQUIRED to match those in a candidate object (according to the matching rules defined above).
 	Attribute []kmip.Attribute
 }
@@ -82,7 +82,7 @@ type LocateResponsePayload struct {
 	// A server MAY elect to omit this value from the Response if it is unable or unwilling to determine the total count of matched items.
 	//
 	// A server MAY elect to return the Located Items value even if Offset Items is not present in the Request.
-	LocatedItems *int32 `ttlv:",version=1.3.."`
+	LocatedItems *int32 `ttlv:",version=v1.3.."`
 	// The Unique Identifier of the located objects.
 	UniqueIdentifier []string
 }

--- a/ttlv/encoder.go
+++ b/ttlv/encoder.go
@@ -261,20 +261,12 @@ func buildDurationEncodeFunc() func(*Encoder, int, reflect.Value) {
 
 func buildTimeEncodeFunc() func(*Encoder, int, reflect.Value) {
 	return func(e *Encoder, tag int, v reflect.Value) {
-		// if v.CanAddr() {
-		// 	e.DateTime(tag, *v.Addr().Interface().(*time.Time))
-		// 	return
-		// }
 		e.DateTime(tag, v.Interface().(time.Time))
 	}
 }
 
 func buildBigIntEncodeFunc() func(*Encoder, int, reflect.Value) {
 	return func(e *Encoder, tag int, v reflect.Value) {
-		// if v.CanAddr() {
-		// 	e.BigInteger(tag, v.Addr().Interface().(*big.Int))
-		// 	return
-		// }
 		n := v.Interface().(big.Int)
 		e.BigInteger(tag, &n)
 	}
@@ -302,8 +294,6 @@ func buildSliceEncodeFunc(ty reflect.Type) func(*Encoder, int, reflect.Value) {
 			e.ByteString(tag, v.Bytes())
 		}
 	}
-	// 	fallthrough
-	// case reflect.Array:
 	ff := encodeFuncFor(ty.Elem())
 	return func(e *Encoder, tag int, v reflect.Value) {
 		for i := range v.Len() {

--- a/ttlv/encoding_xml.go
+++ b/ttlv/encoding_xml.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+// panicOnErr panics on error. Safe here because xmlWriter always writes to a
+// bytes.Buffer, which never returns I/O errors, making these panics unreachable.
 func panicOnErr(err error) {
 	if err != nil {
 		panic(err)

--- a/ttlv/io.go
+++ b/ttlv/io.go
@@ -1,12 +1,17 @@
 package ttlv
 
 import (
+	"errors"
 	"io"
 	"slices"
 )
 
 // DefaultMaxMessageSize is the default maximum allowed size in bytes for a single KMIP message.
 const DefaultMaxMessageSize = 1 * 1024 * 1024 // 1 MB
+
+// ErrMessageTooLarge is returned (wrapped) by Stream.Recv when the incoming
+// message would exceed the configured max size. Use errors.Is to detect it.
+var ErrMessageTooLarge = errors.New("ttlv: message exceeds max size")
 
 // computeNeededBytes calculates the number of bytes needed to process a TTLV-encoded buffer.
 // If the buffer length is less than 8 bytes, it returns 8 as the minimum required size.
@@ -74,7 +79,10 @@ func (s *Stream) Recv(msg any) error {
 		read += n
 		need = computeNeededBytes(buf[:read])
 		if s.max > 0 && need > s.max {
-			return Errorf("Message is too big. Max allowed size is %d bytes", s.max)
+			// Errorf wraps in ErrEncoding (so kmipserver's IsErrEncoding check
+			// still routes this to a structured KMIP error response); %w embeds
+			// the sentinel for callers who use errors.Is.
+			return Errorf("%w: max allowed is %d bytes", ErrMessageTooLarge, s.max)
 		}
 		if read >= need {
 			return UnmarshalTTLV(buf[:need], msg)
@@ -82,9 +90,9 @@ func (s *Stream) Recv(msg any) error {
 	}
 }
 
-// Roundtrip simply perform a Send() followed by a Recv(),
+// RoundTrip simply performs a Send() followed by a Recv(),
 // sending `req` then receiving `resp`.
-func (s *Stream) Roundtrip(req, resp any) error {
+func (s *Stream) RoundTrip(req, resp any) error {
 	if err := s.Send(req); err != nil {
 		return err
 	}

--- a/ttlv/io_test.go
+++ b/ttlv/io_test.go
@@ -2,6 +2,7 @@ package ttlv
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"testing"
 
@@ -27,8 +28,10 @@ func TestStream_Recv_MaxMessageSize(t *testing.T) {
 		var out any
 		err := stream.Recv(&out)
 		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrMessageTooLarge))
+		// Stream.Recv wraps the sentinel in ErrEncoding so that kmipserver's
+		// IsErrEncoding routing still produces a structured KMIP error response.
 		assert.True(t, IsErrEncoding(err))
-		assert.Contains(t, err.Error(), "too big")
 	})
 
 	t.Run("accepted when message fits max size", func(t *testing.T) {


### PR DESCRIPTION
Adds an optional HTTP transport for the KMIP client so it can talk to servers exposing KMIP over HTTPS, alongside the existing TTLV-over-TLS stream protocol.

The transport lives in a new `kmipclient/kmiphttp` sub-package so importing `kmipclient` alone does **not** link `net/http`; only callers that use HTTPS pay that cost.

```go
import (
    "github.com/ovh/kmip-go/kmipclient"
    "github.com/ovh/kmip-go/kmipclient/kmiphttp"
)

client, err := kmipclient.Dial(
    "kms.example.com:8443",
    kmiphttp.WithTransport("/kmip"),
    kmipclient.WithClientCertFiles("cert.pem", "key.pem"),
)
```

Wire format defaults to TTLV (binary) and can be switched to XML or JSON via `kmiphttp.WithWireFormat`. TLS, dialer, and pooling are wired through the existing kmipclient TLS options. For more advanced needs, `kmiphttp.WithClient`, `kmiphttp.WrapRoundTripper`, and `kmiphttp.WithHeader` are available. Non-2xx responses come back as a typed `*kmiphttp.Error` (carries `StatusCode` and a bounded body excerpt) so callers can `errors.As` on it instead of matching error strings.

The client is refactored around an exported `Transport` interface so the stream and HTTP transports share `RoundTrip`/`Clone`/`Close` semantics. Third parties can plug in their own transports via the new `WithTransportBuilder` option and `DialInfo` type — the kmiphttp sub-package is itself implemented on top of this hook. HTTP is intentionally mutually exclusive with `DialCluster`, which has no cluster failover story over HTTP, so combining the two errors out at `Dial` time.

## Architecture

```
                        ┌──────────────────────────┐
                        │   kmipclient.Client      │
                        └────────────┬─────────────┘
                                     │ RoundTrip
                                     ▼
                        ╔══════════════════════════╗
                        ║   Transport (interface)  ║
                        ║   RoundTrip/Clone/Close  ║
                        ╚════╤════════╤════════╤═══╝
              ┌──────────────┘        │        └──────────────┐
              │ default               │ opt-in                │ user-supplied
              ▼                       ▼                       ▼
   ┌────────────────────┐  ┌────────────────────┐  ┌────────────────────┐
   │  streamTransport   │  │ kmiphttp.transport │  │ WithTransport-     │
   │                    │  │  TTLV / XML / JSON │  │  Builder           │
   │      *conn         │  │   *http.Client     │  │                    │
   └─────────┬──────────┘  └──────────┬─────────┘  └──────────┬─────────┘
             │                        │                       │
        DialerFunc               DialerFunc                   │
             │                        │                       │
             ▼                        ▼                       ▼
        TLS / TCP                   HTTPS                 (custom)
             │                        │
             ▼                        ▼
       KMIP :5696            KMIP-over-HTTPS
```

Resolves #58. Supersedes #74.

## Breaking changes

- `Roundtrip` is renamed to `RoundTrip` on `kmipclient.Client`, the new `kmipclient.Transport` interface, and `ttlv.Stream` — matching Go's convention and the `http.RoundTripper` precedent.

- `DialerFunc` now takes the target address as a second argument:
  ```go
  // before
  func(ctx context.Context) (net.Conn, error)
  // after
  func(ctx context.Context, addr string) (net.Conn, error)
  ```
  This lets a single `DialerFunc` serve a cluster (`DialCluster` calls it once per member) and back the HTTP transport's `DialTLSContext`. Existing `WithDialerUnsafe` implementations need to honor `addr` rather than hard-coding a target.

- Client-side detection of oversized responses moves from `ttlv.IsErrEncoding(err)` to `errors.Is(err, kmipclient.ErrResponseTooLarge)`. The ttlv package gains a new `ErrMessageTooLarge` sentinel that the stream transport wraps as `ErrResponseTooLarge`; server-side `IsErrEncoding` routing is unchanged.