### PR TITLE
ci(release-notes): filter empty breaking descriptions and normalize newlines

### DIFF
--- a/.github/release-note.toml
+++ b/.github/release-note.toml
@@ -18,13 +18,15 @@ body = """
             {% if commit.breaking %}[**breaking**] {% endif %}\
             {{ commit.message | upper_first }}\
     {% endfor %}
-  {% endfor %}
-{% set breaking = (commits | filter(attribute="breaking", value=true) | map(attribute="breaking_description")) -%}
+{% endfor %}
+{% set breaking = (commits | filter(attribute="breaking", value=true)
+                           | filter(attribute="breaking_description")
+                           | map(attribute="breaking_description")) -%}
 {% if breaking -%}
-  ### ⚠️ BREAKING CHANGES:
-  {% for bk in breaking %}
-    - {{ bk -}} 
-  {% endfor %}
+    ### ⚠️ BREAKING CHANGES:
+    {% for bk in breaking %}
+        - {{ bk | replace(from="\n", to=" ") -}}
+    {% endfor %}
 {% endif %}
 """
 # template for the changelog footer


### PR DESCRIPTION
## Summary
- Filter out breaking commits without a `breaking_description` so they don't render as empty bullets
- Replace newlines inside breaking descriptions with spaces to keep each entry on a single line
- Tidy up template indentation